### PR TITLE
chore: simplify to main-only branching strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
   build-and-test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,23 +3,21 @@
 ## Branching Strategy
 
 ```
-main (protected) ← Production-ready
+main (protected)
   │
-  └── develop ← Integration branch
-        │
-        ├── feature/* ← New features
-        ├── fix/* ← Bug fixes
-        └── docs/* ← Documentation
+  ├── feature/* ← New features
+  ├── fix/* ← Bug fixes
+  └── docs/* ← Documentation
 ```
 
 ## PR Workflow
 
-**All changes go through PRs — no direct commits to `main` or `develop`.**
+**All changes go through PRs — no direct commits to `main`.**
 
-1. Create branch from `develop`: `git checkout -b feature/your-feature`
+1. Create branch from `main`: `git checkout -b feature/your-feature`
 2. Make changes, ensure tests pass: `pnpm test:coverage` (≥80%)
-3. Push and create PR to `develop`
-4. After review/approval, squash and merge
+3. Push and create PR to `main`
+4. After CI passes and review/approval, squash and merge
 
 ## Commit Convention
 


### PR DESCRIPTION
## Summary
- Remove develop branch references from CI workflow
- Update CONTRIBUTING.md with simpler main-only workflow

## Test plan
- [x] CI should trigger on PRs to main only

🤖 Generated with [Claude Code](https://claude.com/claude-code)