### PR TITLE
chore(ci): add typecheck to CI and configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      # Group minor/patch updates to reduce PR noise
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Type Check
+        run: pnpm typecheck
+
       - name: Build
         run: pnpm build
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "dev": "tsx watch src/main.ts",
     "start": "node dist/main.js",
     "test": "vitest run",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,9 @@
       "outputs": ["coverage/**"]
     },
     "lint": {},
+    "typecheck": {
+      "dependsOn": ["^build"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
- Add Type Check step to CI workflow before build
- Add typecheck script to all packages (tsc --noEmit)
- Add typecheck task to turbo.json with build dependency
- Configure dependabot for weekly npm and GitHub Actions updates
- Group minor/patch dependency updates to reduce PR noise

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation
- [ ] test: Tests
- [ ] chore: Maintenance

## Checklist
- [ ] Tests pass locally (`pnpm test:coverage`)
- [ ] Coverage >= 80%
- [ ] Code follows project conventions
