### PR TITLE
fix(turbo): add lockfile to globalDependencies for cache invalidation

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["pnpm-lock.yaml"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- Adds `pnpm-lock.yaml` to Turbo's `globalDependencies` to ensure cache invalidation when dependencies change

## Problem
When Dependabot updates dependencies (like the recent Zod v4 upgrade), Turbo's cache wasn't invalidated because source files didn't change. This caused CI to replay cached successful results from the old dependency versions, masking real type errors.

## Solution
By adding the lockfile to `globalDependencies`, any change to dependencies will invalidate the entire Turbo cache, ensuring builds and type checks run fresh against new dependency types.

## Test plan
- [x] Lint passes
- [ ] CI runs fresh (no false cache hits)

🤖 Generated with [Claude Code](https://claude.ai/code)