### PR TITLE
feat(phase4): add graph unit tests and example integrations

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,99 @@
+# polyg-mcp Examples
+
+This directory contains example configurations for running polyg-mcp in various environments.
+
+## Claude Desktop Integration
+
+To use polyg-mcp with Claude Desktop:
+
+1. Build the project:
+   ```bash
+   pnpm install && pnpm build
+   ```
+
+2. Start FalkorDB (using Docker):
+   ```bash
+   docker run -d --name falkordb -p 6379:6379 falkordb/falkordb:latest
+   ```
+
+3. Copy `claude-desktop-config.json` to your Claude Desktop config location:
+   - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+   - Linux: `~/.config/Claude/claude_desktop_config.json`
+
+4. Update the config:
+   - Replace `/path/to/polyg-mcp` with your actual installation path
+   - Set your OpenAI API key in the `POLYG_LLM_API_KEY` field
+
+5. Restart Claude Desktop
+
+## Docker Compose
+
+To run polyg-mcp with FalkorDB using Docker Compose:
+
+1. Set your OpenAI API key:
+   ```bash
+   export OPENAI_API_KEY=your-api-key-here
+   ```
+
+2. Start the services:
+   ```bash
+   docker compose -f examples/docker-compose.yml up -d
+   ```
+
+3. Check health:
+   ```bash
+   curl http://localhost:3000/health
+   ```
+
+4. Stop the services:
+   ```bash
+   docker compose -f examples/docker-compose.yml down
+   ```
+
+## Available MCP Tools
+
+Once connected, the following tools are available:
+
+### High-Level Tools
+- `recall` - Query memory using natural language (LLM-powered)
+- `remember` - Store new information (extracts entities, facts, events)
+
+### Entity Graph
+- `get_entity` - Get entity by name/UUID with relationships
+- `add_entity` - Create a new entity
+- `link_entities` - Create relationship between entities
+
+### Temporal Graph
+- `query_timeline` - Query events in a time range
+- `add_event` - Add a new event
+- `add_fact` - Add a time-bounded fact
+
+### Causal Graph
+- `get_causal_chain` - Get upstream causes or downstream effects
+- `add_causal_link` - Create cause-effect relationship
+- `explain_why` - Get causal explanation for an event
+
+### Semantic Graph
+- `search_semantic` - Semantic similarity search
+- `add_concept` - Add concept with auto-generated embedding
+
+### Management
+- `get_statistics` - Get statistics about all graphs
+- `clear_graph` - Clear specified graph(s)
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `POLYG_FALKORDB_HOST` | FalkorDB host | `localhost` |
+| `POLYG_FALKORDB_PORT` | FalkorDB port | `6379` |
+| `POLYG_FALKORDB_GRAPH_NAME` | Graph name | `polyg_memory` |
+| `POLYG_LLM_PROVIDER` | LLM provider | `openai` |
+| `POLYG_LLM_MODEL` | LLM model | `gpt-4o-mini` |
+| `POLYG_LLM_API_KEY` | API key for LLM | - |
+| `POLYG_EMBEDDINGS_PROVIDER` | Embeddings provider | `openai` |
+| `POLYG_EMBEDDINGS_MODEL` | Embeddings model | `text-embedding-3-small` |
+| `POLYG_EMBEDDINGS_DIMENSIONS` | Embedding dimensions | `1536` |
+| `POLYG_MODE` | Server mode (`stdio`/`http`) | `stdio` |
+| `PORT` | HTTP port (when in http mode) | `3000` |

--- a/examples/claude-desktop-config.json
+++ b/examples/claude-desktop-config.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/claude-desktop/main/schemas/config.schema.json",
+  "mcpServers": {
+    "polyg-mcp": {
+      "command": "node",
+      "args": ["/path/to/polyg-mcp/packages/server/dist/main.js"],
+      "env": {
+        "POLYG_FALKORDB_HOST": "localhost",
+        "POLYG_FALKORDB_PORT": "6379",
+        "POLYG_FALKORDB_GRAPH_NAME": "polyg_memory",
+        "POLYG_LLM_PROVIDER": "openai",
+        "POLYG_LLM_MODEL": "gpt-4o-mini",
+        "POLYG_LLM_API_KEY": "your-openai-api-key-here",
+        "POLYG_EMBEDDINGS_PROVIDER": "openai",
+        "POLYG_EMBEDDINGS_MODEL": "text-embedding-3-small",
+        "POLYG_EMBEDDINGS_DIMENSIONS": "1536"
+      }
+    }
+  }
+}

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,57 @@
+# Docker Compose configuration for polyg-mcp with FalkorDB
+# Usage: docker compose -f examples/docker-compose.yml up -d
+
+services:
+  # FalkorDB - Graph database for polyg-mcp
+  falkordb:
+    image: falkordb/falkordb:latest
+    container_name: polyg-falkordb
+    ports:
+      - "6379:6379"
+    volumes:
+      - falkordb_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # polyg-mcp server (HTTP mode for development/testing)
+  polyg-mcp:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    container_name: polyg-mcp-server
+    ports:
+      - "3000:3000"
+    environment:
+      # FalkorDB connection
+      POLYG_FALKORDB_HOST: falkordb
+      POLYG_FALKORDB_PORT: "6379"
+      POLYG_FALKORDB_GRAPH_NAME: polyg_memory
+      # LLM configuration (OpenAI)
+      POLYG_LLM_PROVIDER: openai
+      POLYG_LLM_MODEL: gpt-4o-mini
+      POLYG_LLM_API_KEY: ${OPENAI_API_KEY}
+      # Embedding configuration
+      POLYG_EMBEDDINGS_PROVIDER: openai
+      POLYG_EMBEDDINGS_MODEL: text-embedding-3-small
+      POLYG_EMBEDDINGS_DIMENSIONS: "1536"
+      # Server mode
+      POLYG_MODE: http
+      PORT: "3000"
+    depends_on:
+      falkordb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 10s
+      retries: 3
+    restart: unless-stopped
+
+volumes:
+  falkordb_data:
+    driver: local

--- a/packages/core/src/graphs/causal.test.ts
+++ b/packages/core/src/graphs/causal.test.ts
@@ -1,0 +1,472 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FalkorDBAdapter } from '../storage/falkordb.js';
+import { CausalGraph } from './causal.js';
+import { CausalTraversalError, GraphParseError } from './errors.js';
+
+// Mock FalkorDBAdapter
+function createMockDb(): FalkorDBAdapter {
+  return {
+    query: vi.fn(),
+    createNode: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  } as unknown as FalkorDBAdapter;
+}
+
+// Helper to create a mock causal node
+function mockCausalNode(props: Record<string, unknown> = {}) {
+  return {
+    properties: {
+      uuid: 'causal-node-uuid',
+      description: 'Test causal node',
+      node_type: 'event',
+      ...props,
+    },
+  };
+}
+
+describe('CausalGraph', () => {
+  let db: FalkorDBAdapter;
+  let graph: CausalGraph;
+
+  beforeEach(() => {
+    db = createMockDb();
+    graph = new CausalGraph(db);
+    vi.clearAllMocks();
+  });
+
+  describe('addNode', () => {
+    it('should create a new causal node', async () => {
+      vi.mocked(db.createNode).mockResolvedValue('new-causal-uuid');
+
+      const node = await graph.addNode('Rain started', 'cause');
+
+      expect(db.createNode).toHaveBeenCalledWith('C_Node', {
+        description: 'Rain started',
+        node_type: 'cause',
+        created_at: expect.any(String),
+      });
+      expect(node).toMatchObject({
+        uuid: 'new-causal-uuid',
+        description: 'Rain started',
+        node_type: 'cause',
+      });
+    });
+
+    it('should throw on database error', async () => {
+      vi.mocked(db.createNode).mockRejectedValue(new Error('DB error'));
+
+      await expect(graph.addNode('Test', 'type')).rejects.toThrow(
+        'Failed to add causal node: Test',
+      );
+    });
+  });
+
+  describe('getNode', () => {
+    it('should return node by UUID', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ n: mockCausalNode() }],
+        metadata: [],
+      });
+
+      const node = await graph.getNode('uuid');
+
+      expect(node?.description).toBe('Test causal node');
+    });
+
+    it('should return null for nonexistent node', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      const node = await graph.getNode('nonexistent');
+
+      expect(node).toBeNull();
+    });
+  });
+
+  describe('addLink', () => {
+    it('should create causal link between nodes', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({ records: [], metadata: [] }) // CREATE
+        .mockResolvedValueOnce({
+          records: [{ n: mockCausalNode({ description: 'Cause' }) }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({
+          records: [{ n: mockCausalNode({ description: 'Effect' }) }],
+          metadata: [],
+        });
+
+      const link = await graph.addLink('cause-uuid', 'effect-uuid', 0.8);
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE'),
+        expect.objectContaining({
+          causeId: 'cause-uuid',
+          effectId: 'effect-uuid',
+          confidence: 0.8,
+        }),
+      );
+      expect(link.confidence).toBe(0.8);
+    });
+
+    it('should use default confidence of 1.0', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({ records: [], metadata: [] })
+        .mockResolvedValueOnce({
+          records: [{ n: mockCausalNode() }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({
+          records: [{ n: mockCausalNode() }],
+          metadata: [],
+        });
+
+      const link = await graph.addLink('cause', 'effect');
+
+      expect(link.confidence).toBe(1.0);
+    });
+
+    it('should include evidence when provided', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({ records: [], metadata: [] })
+        .mockResolvedValueOnce({
+          records: [{ n: mockCausalNode() }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({
+          records: [{ n: mockCausalNode() }],
+          metadata: [],
+        });
+
+      const link = await graph.addLink(
+        'cause',
+        'effect',
+        0.9,
+        'Research paper',
+      );
+
+      expect(link.evidence).toBe('Research paper');
+    });
+
+    it('should throw RelationshipError on failure', async () => {
+      vi.mocked(db.query).mockRejectedValue(new Error('Link failed'));
+
+      await expect(graph.addLink('cause', 'effect')).rejects.toThrow(
+        'Failed to create causal link',
+      );
+    });
+  });
+
+  describe('getUpstreamCauses', () => {
+    it('should return upstream causal chain', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          {
+            c: mockCausalNode({ description: 'Root cause' }),
+            e: mockCausalNode({ description: 'Effect' }),
+            confidence: 0.9,
+            evidence: 'Study',
+          },
+        ],
+        metadata: [],
+      });
+
+      const causes = await graph.getUpstreamCauses('node-uuid');
+
+      expect(causes).toHaveLength(1);
+      expect(causes[0].cause).toBe('Root cause');
+      expect(causes[0].effect).toBe('Effect');
+      expect(causes[0].confidence).toBe(0.9);
+    });
+
+    it('should use default maxDepth of 3', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.getUpstreamCauses('uuid');
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('*1..3'),
+        expect.any(Object),
+      );
+    });
+
+    it('should respect custom maxDepth', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.getUpstreamCauses('uuid', 5);
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('*1..5'),
+        expect.any(Object),
+      );
+    });
+
+    it('should throw CausalTraversalError on failure', async () => {
+      vi.mocked(db.query).mockRejectedValue(new Error('Query failed'));
+
+      await expect(graph.getUpstreamCauses('uuid')).rejects.toThrow(
+        CausalTraversalError,
+      );
+    });
+  });
+
+  describe('getDownstreamEffects', () => {
+    it('should return downstream effects chain', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          {
+            c: mockCausalNode({ description: 'Cause' }),
+            e: mockCausalNode({ description: 'Downstream effect' }),
+            confidence: 0.85,
+            evidence: null,
+          },
+        ],
+        metadata: [],
+      });
+
+      const effects = await graph.getDownstreamEffects('node-uuid');
+
+      expect(effects).toHaveLength(1);
+      expect(effects[0].effect).toBe('Downstream effect');
+    });
+
+    it('should handle missing evidence', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          {
+            c: mockCausalNode(),
+            e: mockCausalNode(),
+            confidence: 1.0,
+          },
+        ],
+        metadata: [],
+      });
+
+      const effects = await graph.getDownstreamEffects('uuid');
+
+      expect(effects[0].evidence).toBeUndefined();
+    });
+  });
+
+  describe('traverse', () => {
+    it('should traverse upstream only', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ n: mockCausalNode({ uuid: 'found-uuid' }) }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({
+          records: [
+            {
+              c: mockCausalNode({ description: 'Upstream' }),
+              e: mockCausalNode(),
+              confidence: 0.8,
+            },
+          ],
+          metadata: [],
+        });
+
+      const links = await graph.traverse([{ mention: 'test' }], 'upstream');
+
+      expect(links.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should traverse downstream only', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ n: mockCausalNode() }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({
+          records: [],
+          metadata: [],
+        });
+
+      const links = await graph.traverse([{ mention: 'test' }], 'downstream');
+
+      expect(links).toBeDefined();
+    });
+
+    it('should traverse both directions', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ n: mockCausalNode() }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({ records: [], metadata: [] })
+        .mockResolvedValueOnce({ records: [], metadata: [] });
+
+      const links = await graph.traverse([{ mention: 'test' }], 'both');
+
+      expect(links).toBeDefined();
+    });
+
+    it('should deduplicate links', async () => {
+      const commonLink = {
+        c: mockCausalNode({ description: 'A' }),
+        e: mockCausalNode({ description: 'B' }),
+        confidence: 1.0,
+      };
+
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ n: mockCausalNode() }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({ records: [commonLink], metadata: [] })
+        .mockResolvedValueOnce({ records: [commonLink], metadata: [] });
+
+      const links = await graph.traverse([{ mention: 'test' }], 'both');
+
+      // Should deduplicate identical links
+      const uniqueKeys = new Set(links.map((l) => `${l.cause}->${l.effect}`));
+      expect(uniqueKeys.size).toBe(links.length);
+    });
+  });
+
+  describe('explainWhy', () => {
+    it('should find causal explanation for event', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ n: mockCausalNode({ uuid: 'effect-uuid' }) }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({
+          records: [
+            {
+              c: mockCausalNode({ description: 'Root cause' }),
+              e: mockCausalNode({ description: 'Event' }),
+              confidence: 0.95,
+            },
+          ],
+          metadata: [],
+        });
+
+      const explanation = await graph.explainWhy('something happened');
+
+      expect(explanation).toHaveLength(1);
+      expect(explanation[0].cause).toBe('Root cause');
+    });
+
+    it('should return sorted by confidence', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ n: mockCausalNode() }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({
+          records: [
+            {
+              c: mockCausalNode({ description: 'Low' }),
+              e: mockCausalNode(),
+              confidence: 0.5,
+            },
+            {
+              c: mockCausalNode({ description: 'High' }),
+              e: mockCausalNode(),
+              confidence: 0.9,
+            },
+          ],
+          metadata: [],
+        });
+
+      const explanation = await graph.explainWhy('event');
+
+      expect(explanation[0].confidence).toBeGreaterThanOrEqual(
+        explanation[1]?.confidence ?? 0,
+      );
+    });
+
+    it('should return empty array when no explanation found', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      const explanation = await graph.explainWhy('unknown event');
+
+      expect(explanation).toEqual([]);
+    });
+  });
+
+  describe('linkToEvent', () => {
+    it('should create cross-graph link to event', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.linkToEvent('causal-node', 'event-uuid');
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('X_REFERS_TO'),
+        expect.objectContaining({
+          nodeId: 'causal-node',
+          eventId: 'event-uuid',
+        }),
+      );
+    });
+  });
+
+  describe('linkToEntity', () => {
+    it('should create cross-graph link to entity', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.linkToEntity('causal-node', 'entity-uuid');
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('X_AFFECTS'),
+        expect.objectContaining({
+          nodeId: 'causal-node',
+          entityId: 'entity-uuid',
+        }),
+      );
+    });
+  });
+
+  describe('findOrCreate', () => {
+    it('should return existing node if found', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ n: mockCausalNode({ description: 'Existing' }) }],
+        metadata: [],
+      });
+
+      const node = await graph.findOrCreate('Existing');
+
+      expect(node.description).toBe('Existing');
+      expect(db.createNode).not.toHaveBeenCalled();
+    });
+
+    it('should create new node if not found', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      vi.mocked(db.createNode).mockResolvedValue('new-uuid');
+
+      await graph.findOrCreate('New node', 'custom-type');
+
+      expect(db.createNode).toHaveBeenCalledWith(
+        'C_Node',
+        expect.objectContaining({
+          description: 'New node',
+          node_type: 'custom-type',
+        }),
+      );
+    });
+
+    it('should use default node type "event"', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      vi.mocked(db.createNode).mockResolvedValue('uuid');
+
+      await graph.findOrCreate('Description');
+
+      expect(db.createNode).toHaveBeenCalledWith(
+        'C_Node',
+        expect.objectContaining({ node_type: 'event' }),
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('should wrap parse errors in GraphParseError', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ n: { properties: {} } }], // Missing required fields
+        metadata: [],
+      });
+
+      await expect(graph.getNode('uuid')).rejects.toThrow(GraphParseError);
+    });
+  });
+});

--- a/packages/core/src/graphs/entity.test.ts
+++ b/packages/core/src/graphs/entity.test.ts
@@ -1,0 +1,407 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FalkorDBAdapter } from '../storage/falkordb.js';
+import { EntityGraph } from './entity.js';
+import { EntityNotFoundError, GraphParseError } from './errors.js';
+
+// Mock FalkorDBAdapter
+function createMockDb(): FalkorDBAdapter {
+  return {
+    query: vi.fn(),
+    createNode: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  } as unknown as FalkorDBAdapter;
+}
+
+// Helper to create a mock FalkorDB node
+function mockNode(props: Record<string, unknown>) {
+  return {
+    properties: {
+      uuid: 'test-uuid-123',
+      name: 'Test Entity',
+      entity_type: 'person',
+      properties: '{}',
+      created_at: '2024-01-01T00:00:00.000Z',
+      ...props,
+    },
+  };
+}
+
+describe('EntityGraph', () => {
+  let db: FalkorDBAdapter;
+  let graph: EntityGraph;
+
+  beforeEach(() => {
+    db = createMockDb();
+    graph = new EntityGraph(db);
+    vi.clearAllMocks();
+  });
+
+  describe('addEntity', () => {
+    it('should create a new entity with basic properties', async () => {
+      vi.mocked(db.createNode).mockResolvedValue('generated-uuid');
+
+      const entity = await graph.addEntity('Alice', 'person');
+
+      expect(db.createNode).toHaveBeenCalledWith('E_Entity', {
+        name: 'Alice',
+        entity_type: 'person',
+        properties: '{}',
+        created_at: expect.any(String),
+      });
+      expect(entity).toMatchObject({
+        uuid: 'generated-uuid',
+        name: 'Alice',
+        entity_type: 'person',
+        properties: {},
+      });
+    });
+
+    it('should create an entity with custom properties', async () => {
+      vi.mocked(db.createNode).mockResolvedValue('uuid-with-props');
+
+      const entity = await graph.addEntity('Acme Inc', 'company', {
+        industry: 'tech',
+        employees: 100,
+      });
+
+      expect(db.createNode).toHaveBeenCalledWith('E_Entity', {
+        name: 'Acme Inc',
+        entity_type: 'company',
+        properties: JSON.stringify({ industry: 'tech', employees: 100 }),
+        created_at: expect.any(String),
+      });
+      expect(entity.properties).toEqual({ industry: 'tech', employees: 100 });
+    });
+
+    it('should throw on database error', async () => {
+      vi.mocked(db.createNode).mockRejectedValue(new Error('DB Error'));
+
+      await expect(graph.addEntity('Test', 'type')).rejects.toThrow(
+        'Failed to add entity: Test',
+      );
+    });
+  });
+
+  describe('getEntity', () => {
+    it('should find entity by UUID', async () => {
+      vi.mocked(db.query).mockResolvedValueOnce({
+        records: [{ n: mockNode({ uuid: 'uuid-123' }) }],
+        metadata: [],
+      });
+
+      const entity = await graph.getEntity('uuid-123');
+
+      expect(entity).toMatchObject({
+        uuid: 'uuid-123',
+        name: 'Test Entity',
+        entity_type: 'person',
+      });
+    });
+
+    it('should find entity by name when UUID not found', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({ records: [], metadata: [] }) // UUID search
+        .mockResolvedValueOnce({
+          // Name search
+          records: [{ n: mockNode({ name: 'Alice' }) }],
+          metadata: [],
+        });
+
+      const entity = await graph.getEntity('Alice');
+
+      expect(db.query).toHaveBeenCalledTimes(2);
+      expect(entity?.name).toBe('Alice');
+    });
+
+    it('should return null when entity not found', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      const entity = await graph.getEntity('nonexistent');
+
+      expect(entity).toBeNull();
+    });
+
+    it('should parse JSON properties', async () => {
+      vi.mocked(db.query).mockResolvedValueOnce({
+        records: [
+          {
+            n: mockNode({
+              properties: JSON.stringify({ role: 'admin', active: true }),
+            }),
+          },
+        ],
+        metadata: [],
+      });
+
+      const entity = await graph.getEntity('uuid');
+
+      expect(entity?.properties).toEqual({ role: 'admin', active: true });
+    });
+
+    it('should handle invalid JSON properties gracefully', async () => {
+      vi.mocked(db.query).mockResolvedValueOnce({
+        records: [{ n: mockNode({ properties: 'invalid-json' }) }],
+        metadata: [],
+      });
+
+      const entity = await graph.getEntity('uuid');
+
+      expect(entity?.properties).toEqual({});
+    });
+  });
+
+  describe('updateEntity', () => {
+    it('should merge properties on existing entity', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ n: mockNode({ properties: '{"a":1}' }) }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({ records: [], metadata: [] });
+
+      const updated = await graph.updateEntity('uuid', { b: 2 });
+
+      expect(updated.properties).toEqual({ a: 1, b: 2 });
+      expect(db.query).toHaveBeenCalledWith(expect.stringContaining('SET'), {
+        uuid: 'test-uuid-123',
+        properties: JSON.stringify({ a: 1, b: 2 }),
+      });
+    });
+
+    it('should throw EntityNotFoundError when entity does not exist', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await expect(graph.updateEntity('nonexistent', {})).rejects.toThrow(
+        EntityNotFoundError,
+      );
+    });
+  });
+
+  describe('deleteEntity', () => {
+    it('should delete entity and its relationships', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ n: mockNode({}) }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({ records: [], metadata: [] });
+
+      await graph.deleteEntity('uuid');
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('DETACH DELETE'),
+        expect.any(Object),
+      );
+    });
+
+    it('should throw EntityNotFoundError when entity does not exist', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await expect(graph.deleteEntity('nonexistent')).rejects.toThrow(
+        EntityNotFoundError,
+      );
+    });
+  });
+
+  describe('linkEntities', () => {
+    it('should create relationship between two entities', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ n: mockNode({ uuid: 'source-uuid' }) }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({
+          records: [{ n: mockNode({ uuid: 'target-uuid' }) }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({ records: [], metadata: [] });
+
+      await graph.linkEntities('source', 'target', 'WORKS_FOR');
+
+      expect(db.query).toHaveBeenLastCalledWith(
+        expect.stringContaining('CREATE'),
+        expect.objectContaining({
+          relType: 'WORKS_FOR',
+        }),
+      );
+    });
+
+    it('should throw when source entity not found', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await expect(
+        graph.linkEntities('nonexistent', 'target', 'REL'),
+      ).rejects.toThrow(EntityNotFoundError);
+    });
+
+    it('should throw when target entity not found', async () => {
+      // First query returns source (UUID search)
+      // Second query returns empty (UUID search for source name)
+      // Third query returns source found by name
+      // Fourth query returns empty (UUID search for target)
+      // Fifth query returns empty (name search for target)
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ n: mockNode({ uuid: 'source-uuid', name: 'Source' }) }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({ records: [], metadata: [] }) // target UUID search
+        .mockResolvedValueOnce({ records: [], metadata: [] }); // target name search
+
+      await expect(
+        graph.linkEntities('source-uuid', 'nonexistent', 'REL'),
+      ).rejects.toThrow(EntityNotFoundError);
+    });
+  });
+
+  describe('getRelationships', () => {
+    it('should return both incoming and outgoing relationships', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ n: mockNode({ uuid: 'entity-uuid' }) }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({
+          records: [
+            {
+              s: mockNode({ uuid: 's1', name: 'Source' }),
+              t: mockNode({ uuid: 't1', name: 'Target' }),
+              relType: 'MANAGES',
+            },
+          ],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({
+          records: [
+            {
+              s: mockNode({ uuid: 's2', name: 'Manager' }),
+              t: mockNode({ uuid: 'entity-uuid', name: 'Employee' }),
+              relType: 'SUPERVISES',
+            },
+          ],
+          metadata: [],
+        });
+
+      const relationships = await graph.getRelationships('entity-uuid');
+
+      expect(relationships).toHaveLength(2);
+      expect(relationships[0].relationshipType).toBe('MANAGES');
+      expect(relationships[1].relationshipType).toBe('SUPERVISES');
+    });
+
+    it('should throw EntityNotFoundError for nonexistent entity', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await expect(graph.getRelationships('nonexistent')).rejects.toThrow(
+        EntityNotFoundError,
+      );
+    });
+  });
+
+  describe('search', () => {
+    it('should search entities by name', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          { n: mockNode({ name: 'Alice' }) },
+          { n: mockNode({ name: 'Alison' }) },
+        ],
+        metadata: [],
+      });
+
+      const results = await graph.search('Ali');
+
+      expect(results).toHaveLength(2);
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('toLower'),
+        expect.objectContaining({ query: 'Ali' }),
+      );
+    });
+
+    it('should filter by entity type when provided', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ n: mockNode({ entity_type: 'person' }) }],
+        metadata: [],
+      });
+
+      await graph.search('test', 'person');
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('entity_type'),
+        expect.objectContaining({ type: 'person' }),
+      );
+    });
+  });
+
+  describe('resolve', () => {
+    it('should resolve entity mentions to actual entities', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ n: mockNode({ name: 'Alice' }) }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({ records: [], metadata: [] })
+        .mockResolvedValueOnce({
+          records: [{ n: mockNode({ name: 'Bob' }) }],
+          metadata: [],
+        });
+
+      const resolved = await graph.resolve([
+        { mention: 'Alice' },
+        { mention: 'Bob', type: 'person' },
+      ]);
+
+      expect(resolved).toHaveLength(2);
+    });
+
+    it('should skip unresolved mentions', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      const resolved = await graph.resolve([{ mention: 'Unknown' }]);
+
+      expect(resolved).toHaveLength(0);
+    });
+  });
+
+  describe('getByType', () => {
+    it('should return all entities of a given type', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          { n: mockNode({ entity_type: 'company' }) },
+          { n: mockNode({ entity_type: 'company' }) },
+        ],
+        metadata: [],
+      });
+
+      const entities = await graph.getByType('company');
+
+      expect(entities).toHaveLength(2);
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('entity_type'),
+        expect.objectContaining({ type: 'company', limit: 100 }),
+      );
+    });
+
+    it('should respect the limit parameter', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.getByType('type', 50);
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ limit: 50 }),
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('should wrap parse errors in GraphParseError', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ n: { properties: {} } }], // Missing required fields
+        metadata: [],
+      });
+
+      await expect(graph.getEntity('uuid')).rejects.toThrow(GraphParseError);
+    });
+  });
+});

--- a/packages/core/src/graphs/semantic.test.ts
+++ b/packages/core/src/graphs/semantic.test.ts
@@ -1,0 +1,478 @@
+import type { EmbeddingProvider } from '@polyg-mcp/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FalkorDBAdapter } from '../storage/falkordb.js';
+import { EmbeddingGenerationError, GraphParseError } from './errors.js';
+import { SemanticGraph } from './semantic.js';
+
+// Mock FalkorDBAdapter
+function createMockDb(): FalkorDBAdapter {
+  return {
+    query: vi.fn(),
+    createNode: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  } as unknown as FalkorDBAdapter;
+}
+
+// Mock EmbeddingProvider
+function createMockEmbeddings(): EmbeddingProvider {
+  return {
+    embed: vi.fn(),
+    embedBatch: vi.fn(),
+  };
+}
+
+// Helper to create a mock concept node
+function mockConceptNode(props: Record<string, unknown> = {}) {
+  return {
+    properties: {
+      uuid: 'concept-uuid-123',
+      name: 'Test Concept',
+      description: 'A test concept description',
+      embedding: JSON.stringify([0.1, 0.2, 0.3, 0.4, 0.5]),
+      ...props,
+    },
+  };
+}
+
+describe('SemanticGraph', () => {
+  let db: FalkorDBAdapter;
+  let embeddings: EmbeddingProvider;
+  let graph: SemanticGraph;
+
+  beforeEach(() => {
+    db = createMockDb();
+    embeddings = createMockEmbeddings();
+    graph = new SemanticGraph(db, embeddings);
+    vi.clearAllMocks();
+  });
+
+  describe('addConcept', () => {
+    it('should create a new concept with embedding', async () => {
+      vi.mocked(embeddings.embed).mockResolvedValue([0.1, 0.2, 0.3]);
+      vi.mocked(db.createNode).mockResolvedValue('new-concept-uuid');
+
+      const concept = await graph.addConcept('Machine Learning');
+
+      expect(embeddings.embed).toHaveBeenCalledWith('Machine Learning');
+      expect(db.createNode).toHaveBeenCalledWith('S_Concept', {
+        name: 'Machine Learning',
+        embedding: JSON.stringify([0.1, 0.2, 0.3]),
+        created_at: expect.any(String),
+      });
+      expect(concept).toMatchObject({
+        uuid: 'new-concept-uuid',
+        name: 'Machine Learning',
+        embedding: [0.1, 0.2, 0.3],
+      });
+    });
+
+    it('should include description in embedding text', async () => {
+      vi.mocked(embeddings.embed).mockResolvedValue([0.1, 0.2, 0.3]);
+      vi.mocked(db.createNode).mockResolvedValue('uuid');
+
+      await graph.addConcept('AI', 'Artificial Intelligence systems');
+
+      expect(embeddings.embed).toHaveBeenCalledWith(
+        'AI: Artificial Intelligence systems',
+      );
+      expect(db.createNode).toHaveBeenCalledWith(
+        'S_Concept',
+        expect.objectContaining({
+          description: 'Artificial Intelligence systems',
+        }),
+      );
+    });
+
+    it('should throw EmbeddingGenerationError on embedding failure', async () => {
+      vi.mocked(embeddings.embed).mockRejectedValue(new Error('API error'));
+
+      await expect(graph.addConcept('Test')).rejects.toThrow(
+        EmbeddingGenerationError,
+      );
+    });
+
+    it('should throw on database error', async () => {
+      vi.mocked(embeddings.embed).mockResolvedValue([0.1]);
+      vi.mocked(db.createNode).mockRejectedValue(new Error('DB error'));
+
+      await expect(graph.addConcept('Test')).rejects.toThrow(
+        'Failed to add concept: Test',
+      );
+    });
+  });
+
+  describe('search', () => {
+    it('should find similar concepts by query', async () => {
+      vi.mocked(embeddings.embed).mockResolvedValue([0.1, 0.2, 0.3, 0.4, 0.5]);
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          { c: mockConceptNode({ name: 'Similar Concept 1' }) },
+          { c: mockConceptNode({ name: 'Similar Concept 2' }) },
+        ],
+        metadata: [],
+      });
+
+      const results = await graph.search('test query');
+
+      expect(embeddings.embed).toHaveBeenCalledWith('test query');
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]).toHaveProperty('concept');
+      expect(results[0]).toHaveProperty('score');
+    });
+
+    it('should sort by similarity score descending', async () => {
+      vi.mocked(embeddings.embed).mockResolvedValue([1, 0, 0, 0, 0]);
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          {
+            c: mockConceptNode({
+              embedding: JSON.stringify([0.5, 0.5, 0, 0, 0]),
+            }),
+          },
+          {
+            c: mockConceptNode({ embedding: JSON.stringify([1, 0, 0, 0, 0]) }),
+          },
+        ],
+        metadata: [],
+      });
+
+      const results = await graph.search('query');
+
+      expect(results[0].score).toBeGreaterThanOrEqual(results[1].score);
+    });
+
+    it('should respect limit parameter', async () => {
+      vi.mocked(embeddings.embed).mockResolvedValue([0.1, 0.2, 0.3, 0.4, 0.5]);
+      vi.mocked(db.query).mockResolvedValue({
+        records: Array(20)
+          .fill(null)
+          .map(() => ({ c: mockConceptNode() })),
+        metadata: [],
+      });
+
+      const results = await graph.search('query', 5);
+
+      expect(results).toHaveLength(5);
+    });
+
+    it('should use default limit of 10', async () => {
+      vi.mocked(embeddings.embed).mockResolvedValue([0.1, 0.2, 0.3, 0.4, 0.5]);
+      vi.mocked(db.query).mockResolvedValue({
+        records: Array(15)
+          .fill(null)
+          .map(() => ({ c: mockConceptNode() })),
+        metadata: [],
+      });
+
+      const results = await graph.search('query');
+
+      expect(results).toHaveLength(10);
+    });
+
+    it('should skip concepts without embeddings', async () => {
+      vi.mocked(embeddings.embed).mockResolvedValue([0.1]);
+      // Concept without embedding field - parseConcept returns undefined embedding
+      const nodeWithoutEmbedding = {
+        properties: {
+          uuid: 'no-embed-uuid',
+          name: 'No Embedding',
+        },
+      };
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ c: nodeWithoutEmbedding }, { c: mockConceptNode() }],
+        metadata: [],
+      });
+
+      const results = await graph.search('query');
+
+      expect(results).toHaveLength(1);
+    });
+
+    it('should throw EmbeddingGenerationError on embedding failure', async () => {
+      vi.mocked(embeddings.embed).mockRejectedValue(new Error('API error'));
+
+      await expect(graph.search('query')).rejects.toThrow(
+        EmbeddingGenerationError,
+      );
+    });
+  });
+
+  describe('getConcept', () => {
+    it('should return concept by UUID', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ c: mockConceptNode() }],
+        metadata: [],
+      });
+
+      const concept = await graph.getConcept('uuid');
+
+      expect(concept?.name).toBe('Test Concept');
+      expect(concept?.embedding).toEqual([0.1, 0.2, 0.3, 0.4, 0.5]);
+    });
+
+    it('should return null for nonexistent concept', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      const concept = await graph.getConcept('nonexistent');
+
+      expect(concept).toBeNull();
+    });
+
+    it('should parse embedding from JSON string', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          {
+            c: mockConceptNode({
+              embedding: JSON.stringify([0.5, 0.6, 0.7]),
+            }),
+          },
+        ],
+        metadata: [],
+      });
+
+      const concept = await graph.getConcept('uuid');
+
+      expect(concept?.embedding).toEqual([0.5, 0.6, 0.7]);
+    });
+  });
+
+  describe('getConceptByName', () => {
+    it('should return concept by name (case-insensitive)', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ c: mockConceptNode({ name: 'Machine Learning' }) }],
+        metadata: [],
+      });
+
+      const concept = await graph.getConceptByName('machine learning');
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('toLower'),
+        expect.objectContaining({ name: 'machine learning' }),
+      );
+      expect(concept?.name).toBe('Machine Learning');
+    });
+
+    it('should return null when not found', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      const concept = await graph.getConceptByName('Unknown');
+
+      expect(concept).toBeNull();
+    });
+  });
+
+  describe('getSimilar', () => {
+    it('should find similar concepts to an existing concept', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [{ c: mockConceptNode({ uuid: 'source-uuid' }) }],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({
+          records: [
+            { c: mockConceptNode({ uuid: 'similar-1', name: 'Similar 1' }) },
+            { c: mockConceptNode({ uuid: 'similar-2', name: 'Similar 2' }) },
+          ],
+          metadata: [],
+        });
+
+      const similar = await graph.getSimilar('source-uuid');
+
+      expect(similar.length).toBeGreaterThan(0);
+      expect(db.query).toHaveBeenLastCalledWith(
+        expect.stringContaining('uuid <> $uuid'),
+        expect.any(Object),
+      );
+    });
+
+    it('should return empty array for nonexistent concept', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      const similar = await graph.getSimilar('nonexistent');
+
+      expect(similar).toEqual([]);
+    });
+
+    it('should return empty array for concept without embedding', async () => {
+      // Concept without embedding field - parseConcept returns undefined embedding
+      const nodeWithoutEmbedding = {
+        properties: {
+          uuid: 'no-embed-uuid',
+          name: 'No Embedding',
+        },
+      };
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ c: nodeWithoutEmbedding }],
+        metadata: [],
+      });
+
+      const similar = await graph.getSimilar('uuid');
+
+      expect(similar).toEqual([]);
+    });
+  });
+
+  describe('linkToEntity', () => {
+    it('should create cross-graph link to entity', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.linkToEntity('concept-uuid', 'entity-uuid');
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('X_REPRESENTS'),
+        expect.objectContaining({
+          conceptId: 'concept-uuid',
+          entityId: 'entity-uuid',
+        }),
+      );
+    });
+
+    it('should throw RelationshipError on failure', async () => {
+      vi.mocked(db.query).mockRejectedValue(new Error('Link failed'));
+
+      await expect(graph.linkToEntity('concept', 'entity')).rejects.toThrow(
+        'Failed to link concept to entity',
+      );
+    });
+  });
+
+  describe('updateEmbedding', () => {
+    it('should regenerate embedding for existing concept', async () => {
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({
+          records: [
+            {
+              c: mockConceptNode({
+                name: 'Concept',
+                description: 'Desc',
+              }),
+            },
+          ],
+          metadata: [],
+        })
+        .mockResolvedValueOnce({ records: [], metadata: [] });
+      vi.mocked(embeddings.embed).mockResolvedValue([0.9, 0.8, 0.7]);
+
+      const updated = await graph.updateEmbedding('uuid');
+
+      expect(embeddings.embed).toHaveBeenCalledWith('Concept: Desc');
+      expect(updated?.embedding).toEqual([0.9, 0.8, 0.7]);
+    });
+
+    it('should return null for nonexistent concept', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      const result = await graph.updateEmbedding('nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should throw EmbeddingGenerationError on embedding failure', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ c: mockConceptNode() }],
+        metadata: [],
+      });
+      vi.mocked(embeddings.embed).mockRejectedValue(new Error('API error'));
+
+      await expect(graph.updateEmbedding('uuid')).rejects.toThrow(
+        EmbeddingGenerationError,
+      );
+    });
+  });
+
+  describe('findOrCreate', () => {
+    it('should return existing concept if found', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ c: mockConceptNode({ name: 'Existing' }) }],
+        metadata: [],
+      });
+
+      const concept = await graph.findOrCreate('Existing');
+
+      expect(concept.name).toBe('Existing');
+      expect(embeddings.embed).not.toHaveBeenCalled();
+    });
+
+    it('should create new concept if not found', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      vi.mocked(embeddings.embed).mockResolvedValue([0.1, 0.2]);
+      vi.mocked(db.createNode).mockResolvedValue('new-uuid');
+
+      const concept = await graph.findOrCreate('New Concept', 'Description');
+
+      expect(db.createNode).toHaveBeenCalled();
+      expect(concept.name).toBe('New Concept');
+    });
+  });
+
+  describe('deleteConcept', () => {
+    it('should delete concept by UUID', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.deleteConcept('uuid');
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('DETACH DELETE'),
+        expect.objectContaining({ uuid: 'uuid' }),
+      );
+    });
+  });
+
+  describe('cosineSimilarity', () => {
+    it('should return 1 for identical vectors', async () => {
+      vi.mocked(embeddings.embed).mockResolvedValue([1, 0, 0]);
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          { c: mockConceptNode({ embedding: JSON.stringify([1, 0, 0]) }) },
+        ],
+        metadata: [],
+      });
+
+      const results = await graph.search('query');
+
+      expect(results[0].score).toBeCloseTo(1);
+    });
+
+    it('should return 0 for orthogonal vectors', async () => {
+      vi.mocked(embeddings.embed).mockResolvedValue([1, 0, 0]);
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          { c: mockConceptNode({ embedding: JSON.stringify([0, 1, 0]) }) },
+        ],
+        metadata: [],
+      });
+
+      const results = await graph.search('query');
+
+      expect(results[0].score).toBeCloseTo(0);
+    });
+
+    it('should handle vectors of different lengths gracefully', async () => {
+      vi.mocked(embeddings.embed).mockResolvedValue([1, 0]);
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          {
+            c: mockConceptNode({ embedding: JSON.stringify([1, 0, 0, 0, 0]) }),
+          },
+        ],
+        metadata: [],
+      });
+
+      const results = await graph.search('query');
+
+      expect(results[0].score).toBe(0);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should wrap parse errors in GraphParseError', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ c: { properties: {} } }], // Missing required fields
+        metadata: [],
+      });
+
+      await expect(graph.getConcept('uuid')).rejects.toThrow(GraphParseError);
+    });
+  });
+});

--- a/packages/core/src/graphs/temporal.test.ts
+++ b/packages/core/src/graphs/temporal.test.ts
@@ -1,0 +1,383 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FalkorDBAdapter } from '../storage/falkordb.js';
+import { GraphParseError, TemporalError } from './errors.js';
+import { TemporalGraph } from './temporal.js';
+
+// Mock FalkorDBAdapter
+function createMockDb(): FalkorDBAdapter {
+  return {
+    query: vi.fn(),
+    createNode: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  } as unknown as FalkorDBAdapter;
+}
+
+// Helper to create a mock event node
+function mockEventNode(props: Record<string, unknown> = {}) {
+  return {
+    properties: {
+      uuid: 'event-uuid-123',
+      description: 'Test event occurred',
+      occurred_at: '2024-06-15T10:00:00.000Z',
+      ...props,
+    },
+  };
+}
+
+// Helper to create a mock fact node
+function mockFactNode(props: Record<string, unknown> = {}) {
+  return {
+    properties: {
+      uuid: 'fact-uuid-456',
+      subject: 'Alice',
+      predicate: 'works_at',
+      object: 'Acme Corp',
+      valid_from: '2024-01-01T00:00:00.000Z',
+      ...props,
+    },
+  };
+}
+
+describe('TemporalGraph', () => {
+  let db: FalkorDBAdapter;
+  let graph: TemporalGraph;
+
+  beforeEach(() => {
+    db = createMockDb();
+    graph = new TemporalGraph(db);
+    vi.clearAllMocks();
+  });
+
+  describe('addEvent', () => {
+    it('should create a new event', async () => {
+      vi.mocked(db.createNode).mockResolvedValue('new-event-uuid');
+      const occurredAt = new Date('2024-06-15T10:00:00.000Z');
+
+      const event = await graph.addEvent('Meeting happened', occurredAt);
+
+      expect(db.createNode).toHaveBeenCalledWith('T_Event', {
+        description: 'Meeting happened',
+        occurred_at: occurredAt.toISOString(),
+      });
+      expect(event).toMatchObject({
+        uuid: 'new-event-uuid',
+        description: 'Meeting happened',
+        occurred_at: occurredAt,
+      });
+    });
+
+    it('should create event with duration', async () => {
+      vi.mocked(db.createNode).mockResolvedValue('uuid');
+
+      const event = await graph.addEvent(
+        'Long meeting',
+        new Date(),
+        3600, // 1 hour in seconds
+      );
+
+      expect(db.createNode).toHaveBeenCalledWith(
+        'T_Event',
+        expect.objectContaining({ duration: 3600 }),
+      );
+      expect(event.duration).toBe(3600);
+    });
+
+    it('should throw on database error', async () => {
+      vi.mocked(db.createNode).mockRejectedValue(new Error('DB error'));
+
+      await expect(graph.addEvent('Event', new Date())).rejects.toThrow(
+        'Failed to add event',
+      );
+    });
+  });
+
+  describe('addFact', () => {
+    it('should create a time-bounded fact', async () => {
+      vi.mocked(db.createNode).mockResolvedValue('fact-uuid');
+      const validFrom = new Date('2024-01-01');
+
+      const fact = await graph.addFact('Alice', 'works_at', 'Acme', validFrom);
+
+      expect(db.createNode).toHaveBeenCalledWith('T_Fact', {
+        subject: 'Alice',
+        predicate: 'works_at',
+        object: 'Acme',
+        valid_from: validFrom.toISOString(),
+      });
+      expect(fact).toMatchObject({
+        uuid: 'fact-uuid',
+        subject: 'Alice',
+        predicate: 'works_at',
+        object: 'Acme',
+        valid_from: validFrom,
+        valid_to: undefined,
+      });
+    });
+
+    it('should create fact with end date', async () => {
+      vi.mocked(db.createNode).mockResolvedValue('uuid');
+      const validFrom = new Date('2024-01-01');
+      const validTo = new Date('2024-12-31');
+
+      const fact = await graph.addFact(
+        'Bob',
+        'employed_at',
+        'Corp',
+        validFrom,
+        validTo,
+      );
+
+      expect(db.createNode).toHaveBeenCalledWith(
+        'T_Fact',
+        expect.objectContaining({ valid_to: validTo.toISOString() }),
+      );
+      expect(fact.valid_to).toEqual(validTo);
+    });
+  });
+
+  describe('queryTimeline', () => {
+    it('should return events in chronological order', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          { e: mockEventNode({ occurred_at: '2024-06-15T09:00:00Z' }) },
+          { e: mockEventNode({ occurred_at: '2024-06-15T10:00:00Z' }) },
+        ],
+        metadata: [],
+      });
+
+      const events = await graph.queryTimeline(
+        new Date('2024-06-01'),
+        new Date('2024-06-30'),
+      );
+
+      expect(events).toHaveLength(2);
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('ORDER BY'),
+        expect.objectContaining({
+          from: expect.any(String),
+          to: expect.any(String),
+        }),
+      );
+    });
+
+    it('should filter by entity when provided', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.queryTimeline(new Date(), new Date(), 'entity-uuid');
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('X_INVOLVES'),
+        expect.objectContaining({ entityId: 'entity-uuid' }),
+      );
+    });
+
+    it('should throw TemporalError on query failure', async () => {
+      vi.mocked(db.query).mockRejectedValue(new Error('Query failed'));
+
+      await expect(graph.queryTimeline(new Date(), new Date())).rejects.toThrow(
+        TemporalError,
+      );
+    });
+  });
+
+  describe('getFactsAt', () => {
+    it('should return facts valid at a specific point in time', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [
+          { f: mockFactNode({ valid_from: '2024-01-01' }) }, // No valid_to means still valid
+          {
+            f: mockFactNode({
+              valid_from: '2024-03-01',
+              valid_to: '2024-12-31',
+            }),
+          },
+        ],
+        metadata: [],
+      });
+
+      const facts = await graph.getFactsAt(new Date('2024-06-15'));
+
+      expect(facts).toHaveLength(2);
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('valid_from'),
+        expect.objectContaining({ time: expect.any(String) }),
+      );
+    });
+  });
+
+  describe('getFactsInRange', () => {
+    it('should return facts overlapping with time range', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ f: mockFactNode() }],
+        metadata: [],
+      });
+
+      const facts = await graph.getFactsInRange(
+        new Date('2024-01-01'),
+        new Date('2024-12-31'),
+      );
+
+      expect(facts).toHaveLength(1);
+    });
+  });
+
+  describe('query (with Timeframe)', () => {
+    it('should handle specific timeframe type', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      const result = await graph.query({
+        type: 'specific',
+        value: '2024-06-15T10:00:00Z',
+      });
+
+      expect(result).toHaveProperty('events');
+      expect(result).toHaveProperty('facts');
+    });
+
+    it('should handle range timeframe type', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.query({
+        type: 'range',
+        value: '2024-01-01',
+        end: '2024-12-31',
+      });
+
+      expect(db.query).toHaveBeenCalled();
+    });
+
+    it('should handle relative timeframe "last week"', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      const result = await graph.query({
+        type: 'relative',
+        value: 'last week',
+      });
+
+      expect(result).toBeDefined();
+    });
+
+    it('should handle relative timeframe "last month"', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.query({ type: 'relative', value: 'last month' });
+
+      expect(db.query).toHaveBeenCalled();
+    });
+
+    it('should handle relative timeframe "past year"', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.query({ type: 'relative', value: 'past year' });
+
+      expect(db.query).toHaveBeenCalled();
+    });
+  });
+
+  describe('getEvent', () => {
+    it('should return event by UUID', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ e: mockEventNode() }],
+        metadata: [],
+      });
+
+      const event = await graph.getEvent('event-uuid');
+
+      expect(event?.uuid).toBe('event-uuid-123');
+    });
+
+    it('should return null for nonexistent event', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      const event = await graph.getEvent('nonexistent');
+
+      expect(event).toBeNull();
+    });
+  });
+
+  describe('getFact', () => {
+    it('should return fact by UUID', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ f: mockFactNode() }],
+        metadata: [],
+      });
+
+      const fact = await graph.getFact('fact-uuid');
+
+      expect(fact?.subject).toBe('Alice');
+      expect(fact?.predicate).toBe('works_at');
+    });
+
+    it('should return null for nonexistent fact', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      const fact = await graph.getFact('nonexistent');
+
+      expect(fact).toBeNull();
+    });
+  });
+
+  describe('invalidateFact', () => {
+    it('should set valid_to date on fact', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      const invalidAt = new Date('2024-06-01');
+
+      await graph.invalidateFact('fact-uuid', invalidAt);
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('SET'),
+        expect.objectContaining({
+          uuid: 'fact-uuid',
+          validTo: invalidAt.toISOString(),
+        }),
+      );
+    });
+
+    it('should use current date if not provided', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.invalidateFact('fact-uuid');
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ validTo: expect.any(String) }),
+      );
+    });
+  });
+
+  describe('linkEventToEntity', () => {
+    it('should create cross-graph relationship', async () => {
+      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+
+      await graph.linkEventToEntity('event-uuid', 'entity-uuid');
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining('X_INVOLVES'),
+        expect.objectContaining({
+          eventId: 'event-uuid',
+          entityId: 'entity-uuid',
+        }),
+      );
+    });
+
+    it('should throw RelationshipError on failure', async () => {
+      vi.mocked(db.query).mockRejectedValue(new Error('Link failed'));
+
+      await expect(graph.linkEventToEntity('event', 'entity')).rejects.toThrow(
+        'Failed to link event to entity',
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('should wrap parse errors in GraphParseError', async () => {
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ e: { properties: {} } }], // Missing required fields
+        metadata: [],
+      });
+
+      await expect(graph.getEvent('uuid')).rejects.toThrow(GraphParseError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for all 4 graph classes (105 new tests)
- Add Claude Desktop configuration example
- Add Docker Compose setup with FalkorDB for local development
- Add examples README with setup instructions and tool documentation

## Changes

### Unit Tests
| Graph | Tests | Coverage |
|-------|-------|----------|
| EntityGraph | 24 | CRUD, relationships, search, resolution |
| TemporalGraph | 24 | Events, facts, timelines, timeframes |
| CausalGraph | 27 | Nodes, links, traversal, explanation |
| SemanticGraph | 30 | Concepts, embeddings, similarity search |

### Examples
- `examples/claude-desktop-config.json` - Ready-to-use Claude Desktop config
- `examples/docker-compose.yml` - FalkorDB + polyg-mcp stack
- `examples/README.md` - Setup instructions, tool list, env vars

## Test plan
- [x] All 268 tests pass (203 core, 44 server, 21 shared)
- [x] Lint passes
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)