### PR TITLE
chore(ci): change dependabot frequency to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
     open-pull-requests-limit: 5
     groups:
       # Group minor/patch updates to reduce PR noise
@@ -22,7 +21,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
     commit-message:
       prefix: "chore(ci)"


### PR DESCRIPTION
## Summary
- Change dependabot check frequency from weekly to daily for both npm and GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)