### PR TITLE
test(server): add Zod validation tests for session options

### DIFF
--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -63,6 +63,46 @@ describe('HTTPTransport', () => {
       const transport = new HTTPTransport({ port: 65535 });
       expect(transport).toBeDefined();
     });
+
+    it('should accept valid session options', () => {
+      const transport = new HTTPTransport({
+        port: 3000,
+        sessionTimeoutMs: 1800000,
+        cleanupIntervalMs: 300000,
+        maxSessions: 100,
+      });
+      expect(transport).toBeDefined();
+    });
+
+    it('should throw TransportConfigError for negative sessionTimeoutMs', () => {
+      expect(
+        () =>
+          new HTTPTransport({
+            port: 3000,
+            sessionTimeoutMs: -1,
+          }),
+      ).toThrow(TransportConfigError);
+    });
+
+    it('should throw TransportConfigError for zero maxSessions', () => {
+      expect(
+        () =>
+          new HTTPTransport({
+            port: 3000,
+            maxSessions: 0,
+          }),
+      ).toThrow(TransportConfigError);
+    });
+
+    it('should throw TransportConfigError for non-integer sessionTimeoutMs', () => {
+      expect(
+        () =>
+          new HTTPTransport({
+            port: 3000,
+            sessionTimeoutMs: 1.5,
+          }),
+      ).toThrow(TransportConfigError);
+    });
   });
 
   describe('resources attachment', () => {


### PR DESCRIPTION
Add tests to verify HTTPTransport rejects invalid session configuration:
- Valid session options (sessionTimeoutMs, cleanupIntervalMs, maxSessions)
- Negative sessionTimeoutMs
- Zero maxSessions
- Non-integer sessionTimeoutMs

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation
- [ ] test: Tests
- [ ] chore: Maintenance

## Checklist
- [ ] Tests pass locally (`pnpm test:coverage`)
- [ ] Coverage >= 80%
- [ ] Code follows project conventions
