### PR TITLE
refactor(retrieval): deprecate dead code, remove duplicate seed extra…

### DIFF
--- a/packages/core/src/executor/magma-executor.ts
+++ b/packages/core/src/executor/magma-executor.ts
@@ -25,6 +25,7 @@ import type { SemanticGraph } from '../graphs/semantic.js';
 import type { TemporalGraph } from '../graphs/temporal.js';
 import {
   ExecutorError,
+  extractSeedsFromEnrichedMatches,
   RetrievalValidationError,
   type SeedExtractionResult,
   SubgraphMerger,
@@ -157,7 +158,7 @@ export class MAGMAExecutor {
 
     // Step 2: Extract entity IDs directly from enriched matches (no CrossLinker needed)
     const seedStart = Date.now();
-    const seeds = this.extractSeedsFromEnriched(
+    const seeds = extractSeedsFromEnrichedMatches(
       enrichedMatches,
       this.config.minSemanticScore,
     );
@@ -187,60 +188,6 @@ export class MAGMAExecutor {
         expansionMs,
         mergeMs,
         totalMs: Date.now() - totalStart,
-      },
-    };
-  }
-
-  /**
-   * Extract seed entities from enriched semantic matches.
-   * This replaces the seedFromSemantic() workaround that used CrossLinker.
-   */
-  private extractSeedsFromEnriched(
-    enrichedMatches: EnrichedSemanticMatch[],
-    minScore: number,
-  ): SeedExtractionResult {
-    const entitySeeds: Array<{
-      entityId: string;
-      sourceConceptId: string;
-      semanticScore: number;
-    }> = [];
-    const conceptIds: string[] = [];
-    const seenEntities = new Set<string>();
-    let conceptsWithoutLinks = 0;
-
-    for (const match of enrichedMatches) {
-      // Skip matches below minimum score threshold
-      if (match.score < minScore) {
-        continue;
-      }
-
-      const conceptId = match.concept.uuid;
-      conceptIds.push(conceptId);
-
-      if (match.linkedEntityIds.length === 0) {
-        conceptsWithoutLinks++;
-        continue;
-      }
-
-      for (const entityId of match.linkedEntityIds) {
-        if (!seenEntities.has(entityId)) {
-          seenEntities.add(entityId);
-          entitySeeds.push({
-            entityId,
-            sourceConceptId: conceptId,
-            semanticScore: match.score,
-          });
-        }
-      }
-    }
-
-    return {
-      entitySeeds,
-      conceptIds,
-      stats: {
-        conceptsSearched: enrichedMatches.length,
-        entitiesFound: entitySeeds.length,
-        conceptsWithoutLinks,
       },
     };
   }

--- a/packages/core/src/retrieval/seed-extractor.ts
+++ b/packages/core/src/retrieval/seed-extractor.ts
@@ -41,6 +41,7 @@ export type SeedExtractionResult = z.infer<typeof SeedExtractionResultSchema>;
 
 /**
  * Validate semantic matches array
+ * @deprecated Internal helper for deprecated seedFromSemantic functions
  */
 function validateSemanticMatches(matches: SemanticMatch[]): SemanticMatch[] {
   if (!Array.isArray(matches)) {
@@ -96,7 +97,7 @@ function validateResult(result: SeedExtractionResult): SeedExtractionResult {
 /**
  * Extract entity seeds from semantic search results using X_REPRESENTS links.
  *
- * @deprecated Use SemanticGraph.searchWithEntities() instead.
+ * @deprecated Use extractSeedsFromEnrichedMatches() with SemanticGraph.searchWithEntities() instead.
  * This function performs separate CrossLinker lookups for each concept,
  * which adds unnecessary database round-trips. The new searchWithEntities()
  * method fetches entity IDs in the same query as the semantic search.
@@ -187,6 +188,10 @@ export async function seedFromSemantic(
 /**
  * Batch version of seed extraction for efficiency with large result sets.
  * Groups concepts and makes fewer database calls.
+ *
+ * @deprecated Use extractSeedsFromEnrichedMatches() with SemanticGraph.searchWithEntities() instead.
+ * The new approach fetches entity IDs in the same query as the semantic search,
+ * eliminating the need for batch CrossLinker lookups.
  *
  * @throws {RetrievalValidationError} If inputs are invalid
  * @throws {SeedExtractionError} If extraction fails
@@ -282,6 +287,9 @@ export async function seedFromSemanticBatch(
 
 /**
  * Get unique entity IDs from seeds (simple array for traversal)
+ *
+ * @deprecated Use seeds.map(s => s.entityId) directly instead.
+ * This wrapper adds minimal value and will be removed in a future version.
  */
 export function getEntityIds(seeds: SeedEntity[]): string[] {
   if (!Array.isArray(seeds)) {
@@ -296,6 +304,9 @@ export function getEntityIds(seeds: SeedEntity[]): string[] {
 
 /**
  * Filter seeds by minimum semantic score
+ *
+ * @deprecated Use extractSeedsFromEnrichedMatches() with minScore parameter instead.
+ * Filtering should be done at extraction time, not as a post-processing step.
  */
 export function filterSeedsByScore(
   seeds: SeedEntity[],


### PR DESCRIPTION
## Summary
- Mark 4 unused functions as `@deprecated` in `seed-extractor.ts`
- Remove duplicate `extractSeedsFromEnriched()` private method from `MAGMAExecutor`

## Details

### Dead Code Deprecated
Functions exported but never used in production code:

| Function | Replacement |
|----------|-------------|
| `seedFromSemantic()` | `extractSeedsFromEnrichedMatches()` |
| `seedFromSemanticBatch()` | `extractSeedsFromEnrichedMatches()` |
| `getEntityIds()` | `seeds.map(s => s.entityId)` |
| `filterSeedsByScore()` | `extractSeedsFromEnrichedMatches()` with `minScore` param |

### Duplicate Code Removed
- `MAGMAExecutor.extractSeedsFromEnriched()` was a private copy of `extractSeedsFromEnrichedMatches()`
- Public function has input validation that private method lacked
- Removes 54 lines of duplicated code

## Test plan
- [x] All 690 tests pass
- [x] No behavioral changes (logic is identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)