### PR TITLE
docs(merger): clarify finalScore can exceed 1.0

### DIFF
--- a/packages/core/src/retrieval/subgraph-merger.ts
+++ b/packages/core/src/retrieval/subgraph-merger.ts
@@ -120,6 +120,9 @@ export class SubgraphMerger {
       }
 
       // Calculate final scores with multi-view boost
+      // Note: finalScore can exceed 1.0 when nodes appear in multiple views
+      // (e.g., avgScore=0.8 with 2 views and boost=1.5 → 0.8 × 1.5 = 1.2)
+      // This is intentional - multi-view nodes should rank higher than single-view nodes.
       const scoredNodes: ScoredNode[] = [];
 
       for (const [uuid, info] of nodeMap) {


### PR DESCRIPTION
## Summary
- Documents that `finalScore` in merged subgraph is intentionally unbounded
- Multi-view boost can produce scores > 1.0 (e.g., 0.8 × 1.5 = 1.2)
- This is by design to ensure multi-view nodes rank higher

## Test plan
- [x] No behavioral changes, documentation only

🤖 Generated with [Claude Code](https://claude.ai/code)