### PR TITLE
fix(orchestrator): early return when graph has no results

### DIFF
--- a/packages/core/src/orchestrator.test.ts
+++ b/packages/core/src/orchestrator.test.ts
@@ -69,6 +69,47 @@ function mockSynthesizerOutput(
   };
 }
 
+// Helper to create a mock MAGMAExecutionResult with actual nodes
+// This ensures merged subgraph has nodes so pipeline reaches synthesizer
+function mockExecutionResultWithNodes() {
+  return {
+    merged: {
+      nodes: [
+        {
+          uuid: 'node-1',
+          data: { name: 'Test Entity', entity_type: 'Person' },
+          viewCount: 1,
+          views: ['semantic' as const],
+          finalScore: 0.9,
+        },
+      ],
+      viewContributions: { semantic: 1, entity: 0, temporal: 0, causal: 0 },
+    },
+    seeds: {
+      conceptIds: ['concept-1'],
+      entitySeeds: [
+        {
+          entityId: 'entity-1',
+          sourceConceptId: 'concept-1',
+          semanticScore: 0.9,
+        },
+      ],
+      stats: {
+        conceptsSearched: 1,
+        entitiesFound: 1,
+        conceptsWithoutLinks: 0,
+      },
+    },
+    timing: {
+      semanticMs: 10,
+      seedExtractionMs: 5,
+      expansionMs: 20,
+      mergeMs: 5,
+      totalMs: 40,
+    },
+  };
+}
+
 describe('Orchestrator', () => {
   let db: FalkorDBAdapter;
   let llm: LLMProvider;
@@ -133,13 +174,17 @@ describe('Orchestrator', () => {
         .mockResolvedValueOnce(JSON.stringify(magmaIntent))
         .mockResolvedValueOnce(JSON.stringify(synthesizerOutput));
 
-      // Mock graph queries to return empty (no entities found)
-      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      // Mock executor to return results with nodes (so pipeline reaches synthesizer)
+      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
+      vi.spyOn(orchestrator['executor'], 'execute').mockResolvedValueOnce(
+        mockExecutionResultWithNodes(),
+      );
 
       const result = await orchestrator.recall('Who is Alice?');
 
       expect(result.answer).toBe('Alice is a person');
-      expect(result.sources).toContain('entity');
+      // Sources come from actual viewContributions, not LLM output
+      expect(result.sources).toContain('semantic');
       expect(llm.complete).toHaveBeenCalledTimes(2);
     });
 
@@ -150,7 +195,10 @@ describe('Orchestrator', () => {
       vi.mocked(llm.complete)
         .mockResolvedValueOnce(JSON.stringify(magmaIntent))
         .mockResolvedValueOnce(JSON.stringify(synthesizerOutput));
-      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
+      vi.spyOn(orchestrator['executor'], 'execute').mockResolvedValueOnce(
+        mockExecutionResultWithNodes(),
+      );
 
       await orchestrator.recall(
         'What happened?',
@@ -172,30 +220,32 @@ describe('Orchestrator', () => {
       );
     });
 
-    it('should handle graph expansion with empty results gracefully', async () => {
-      // MAGMA executor handles graph failures gracefully - returns semantic-only
+    it('should return early with no-results response when graph is empty', async () => {
       const magmaIntent = mockMAGMAIntent({
         type: 'WHEN',
         entities: ['deployment'],
         depthHints: { entity: 1, temporal: 3, causal: 1 },
       });
 
-      const synthesizerOutput = mockSynthesizerOutput({
-        answer: 'No temporal events found',
-        confidence: 0.5,
-      });
+      // Only mock classification - synthesizer should NOT be called
+      vi.mocked(llm.complete).mockResolvedValueOnce(
+        JSON.stringify(magmaIntent),
+      );
 
-      vi.mocked(llm.complete)
-        .mockResolvedValueOnce(JSON.stringify(magmaIntent))
-        .mockResolvedValueOnce(JSON.stringify(synthesizerOutput));
-
-      // Return empty results - MAGMA handles this gracefully
+      // Return empty results from all graph queries
       vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
 
       const result = await orchestrator.recall('What happened last week?');
 
-      // Pipeline completes with semantic-only fallback
-      expect(result.answer).toBe('No temporal events found');
+      // Should return early with no-results response
+      expect(result.answer).toContain('No relevant information found');
+      expect(result.confidence).toBe(0);
+      expect(result.sources).toEqual([]);
+      expect(result.follow_ups).toBeDefined();
+      expect(result.follow_ups?.length).toBeGreaterThan(0);
+
+      // Should only call LLM once (classification), not twice (no synthesis)
+      expect(llm.complete).toHaveBeenCalledTimes(1);
     });
 
     it('should throw with context when synthesizer fails', async () => {
@@ -208,7 +258,11 @@ describe('Orchestrator', () => {
         .mockResolvedValueOnce(JSON.stringify(magmaIntent))
         .mockRejectedValueOnce(new Error('LLM rate limited'));
 
-      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      // Need graph data to reach synthesizer
+      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
+      vi.spyOn(orchestrator['executor'], 'execute').mockResolvedValueOnce(
+        mockExecutionResultWithNodes(),
+      );
 
       await expect(orchestrator.recall('test query')).rejects.toThrow(
         'Response synthesis failed: Failed to get LLM response for synthesis',
@@ -230,7 +284,10 @@ describe('Orchestrator', () => {
       vi.mocked(llm.complete)
         .mockResolvedValueOnce(JSON.stringify(magmaIntent))
         .mockResolvedValueOnce(JSON.stringify(synthesizerOutput));
-      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      // biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
+      vi.spyOn(orchestrator['executor'], 'execute').mockResolvedValueOnce(
+        mockExecutionResultWithNodes(),
+      );
 
       const result = await orchestrator.recall('Tell me about the system');
 

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -193,6 +193,21 @@ export class Orchestrator {
       );
     }
 
+    // Early return if no graph data found - skip LLM call to save cost and avoid hallucination
+    if (executionResult.merged.nodes.length === 0) {
+      return {
+        answer:
+          'No relevant information found in the knowledge graph for this query.',
+        confidence: 0,
+        reasoning: {},
+        sources: [],
+        follow_ups: [
+          'Try adding related entities or concepts to the graph',
+          'Rephrase the query with different keywords',
+        ],
+      };
+    }
+
     // Step 3: Linearize merged subgraph for LLM context
     let linearizedContext: LinearizedContext;
     try {
@@ -237,7 +252,20 @@ export class Orchestrator {
     };
 
     try {
-      return await this.synthesizer.synthesize(synthesizerInput);
+      const result = await this.synthesizer.synthesize(synthesizerInput);
+
+      // Override LLM-generated sources with actual view contributions
+      // This ensures sources accurately reflect which graphs provided data
+      const actualSources = Object.entries(
+        executionResult.merged.viewContributions,
+      )
+        .filter(([, count]) => count > 0)
+        .map(([source]) => source);
+
+      return {
+        ...result,
+        sources: actualSources,
+      };
     } catch (error) {
       throw new OrchestratorError(
         `Response synthesis failed: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary

### 1. Early return for empty graph results (1.6.1)
- Adds early return in orchestrator when `merged.nodes.length === 0`
- Skips LLM synthesis call for empty graph results
- Returns standardized low-confidence response with actionable suggestions

### 2. Accurate sources attribution (1.6.6)
- Overrides LLM-generated sources with actual `viewContributions`
- Sources now accurately reflect which graphs provided data (semantic, entity, temporal, causal)
- Prevents LLM from hallucinating source names

## Response when no data found
```json
{
  "answer": "No relevant information found in the knowledge graph for this query.",
  "confidence": 0,
  "reasoning": {},
  "sources": [],
  "follow_ups": [
    "Try adding related entities or concepts to the graph",
    "Rephrase the query with different keywords"
  ]
}
```

## Test plan
- [x] New test: `should return early with no-results response when graph is empty`
- [x] Updated test: sources now come from viewContributions
- [x] All 18 orchestrator tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/code)