### PR TITLE
fix(cross-graph): improve error handling and add validation for X_ links

### DIFF
--- a/packages/core/src/graphs/cross-linker.test.ts
+++ b/packages/core/src/graphs/cross-linker.test.ts
@@ -25,7 +25,11 @@ describe('CrossLinker', () => {
 
   describe('createLink', () => {
     it('should create a cross-graph link', async () => {
-      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      // Mock successful MERGE - returns the source UUID
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ sourceUuid: 'source-uuid' }],
+        metadata: [],
+      });
 
       await crossLinker.createLink(
         'source-uuid',
@@ -44,7 +48,10 @@ describe('CrossLinker', () => {
     });
 
     it('should create X_INVOLVES link', async () => {
-      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ sourceUuid: 'event-uuid' }],
+        metadata: [],
+      });
 
       await crossLinker.createLink('event-uuid', 'entity-uuid', 'X_INVOLVES');
 
@@ -58,7 +65,10 @@ describe('CrossLinker', () => {
     });
 
     it('should create X_REFERS_TO link', async () => {
-      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ sourceUuid: 'causal-uuid' }],
+        metadata: [],
+      });
 
       await crossLinker.createLink('causal-uuid', 'event-uuid', 'X_REFERS_TO');
 
@@ -72,7 +82,10 @@ describe('CrossLinker', () => {
     });
 
     it('should create X_AFFECTS link', async () => {
-      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ sourceUuid: 'causal-uuid' }],
+        metadata: [],
+      });
 
       await crossLinker.createLink('causal-uuid', 'entity-uuid', 'X_AFFECTS');
 
@@ -83,6 +96,56 @@ describe('CrossLinker', () => {
           targetId: 'entity-uuid',
         }),
       );
+    });
+
+    it('should be idempotent - MERGE prevents duplicates', async () => {
+      // MERGE will not create a second link if one already exists
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ sourceUuid: 'source-uuid' }],
+        metadata: [],
+      });
+
+      // Call twice - should not throw
+      await crossLinker.createLink(
+        'source-uuid',
+        'target-uuid',
+        'X_REPRESENTS',
+      );
+      await crossLinker.createLink(
+        'source-uuid',
+        'target-uuid',
+        'X_REPRESENTS',
+      );
+
+      // Both calls should succeed
+      expect(db.query).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw RelationshipError when nodes not found', async () => {
+      // First query (MERGE) returns empty - nodes not found or wrong labels
+      // Second query (existence check) also returns empty - nodes don't exist
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({ records: [], metadata: [] })
+        .mockResolvedValueOnce({ records: [], metadata: [] });
+
+      await expect(
+        crossLinker.createLink('source', 'target', 'X_REPRESENTS'),
+      ).rejects.toThrow('Source or target node not found');
+    });
+
+    it('should throw RelationshipError when node types are wrong', async () => {
+      // First query (MERGE) returns empty - wrong labels
+      // Second query (existence check) returns labels showing mismatch
+      vi.mocked(db.query)
+        .mockResolvedValueOnce({ records: [], metadata: [] })
+        .mockResolvedValueOnce({
+          records: [{ sourceLabels: ['T_Event'], targetLabels: ['C_Node'] }],
+          metadata: [],
+        });
+
+      await expect(
+        crossLinker.createLink('source', 'target', 'X_REPRESENTS'),
+      ).rejects.toThrow('Invalid node types');
     });
 
     it('should throw RelationshipError on database failure', async () => {
@@ -565,7 +628,11 @@ describe('CrossLinker', () => {
     it.each(
       validLinkTypes,
     )('should accept %s as valid link type', async (linkType) => {
-      vi.mocked(db.query).mockResolvedValue({ records: [], metadata: [] });
+      // Mock successful MERGE - returns source UUID
+      vi.mocked(db.query).mockResolvedValue({
+        records: [{ sourceUuid: 'source' }],
+        metadata: [],
+      });
 
       await expect(
         crossLinker.createLink('source', 'target', linkType),

--- a/packages/core/src/graphs/cross-linker.ts
+++ b/packages/core/src/graphs/cross-linker.ts
@@ -24,28 +24,92 @@ export interface CrossLink {
  * - Causal nodes to events (X_REFERS_TO)
  * - Causal nodes to entities (X_AFFECTS)
  */
+// Maps link types to expected source and target node labels
+const LINK_TYPE_CONSTRAINTS: Record<
+  CrossLinkType,
+  { sourceLabels: string[]; targetLabels: string[] }
+> = {
+  X_REPRESENTS: { sourceLabels: ['S_Concept'], targetLabels: ['E_Entity'] },
+  X_INVOLVES: {
+    sourceLabels: ['T_Event', 'T_Fact'],
+    targetLabels: ['E_Entity'],
+  },
+  X_AFFECTS: { sourceLabels: ['C_Node'], targetLabels: ['E_Entity'] },
+  X_REFERS_TO: { sourceLabels: ['C_Node'], targetLabels: ['T_Event'] },
+};
+
 export class CrossLinker {
   constructor(private db: FalkorDBAdapter) {}
 
   /**
-   * Create a cross-graph relationship
+   * Create a cross-graph relationship.
+   * - Uses MERGE for idempotency (prevents duplicates)
+   * - Validates that source/target nodes have correct labels for the link type
    */
   async createLink(
     sourceId: string,
     targetId: string,
     linkType: CrossLinkType,
   ): Promise<void> {
+    // Validate node types match the link type constraints
+    const constraints = LINK_TYPE_CONSTRAINTS[linkType];
+    const sourceLabelsClause = constraints.sourceLabels
+      .map((l) => `'${l}'`)
+      .join(', ');
+    const targetLabelsClause = constraints.targetLabels
+      .map((l) => `'${l}'`)
+      .join(', ');
+
     try {
-      await this.db.query(
+      // Use MERGE for idempotency - won't create duplicate links
+      // Also validate node labels match the expected types for this link
+      const result = await this.db.query(
         `MATCH (s {uuid: $sourceId}), (t {uuid: $targetId})
-         CREATE (s)-[:${linkType} {created_at: $createdAt}]->(t)`,
+         WHERE any(label IN labels(s) WHERE label IN [${sourceLabelsClause}])
+           AND any(label IN labels(t) WHERE label IN [${targetLabelsClause}])
+         MERGE (s)-[r:${linkType}]->(t)
+         ON CREATE SET r.created_at = $createdAt
+         RETURN s.uuid as sourceUuid`,
         {
           sourceId,
           targetId,
           createdAt: new Date().toISOString(),
         },
       );
+
+      // If no records returned, either nodes don't exist or have wrong labels
+      if (result.records.length === 0) {
+        // Check if nodes exist at all
+        const existsResult = await this.db.query(
+          `MATCH (s {uuid: $sourceId}), (t {uuid: $targetId})
+           RETURN labels(s) as sourceLabels, labels(t) as targetLabels`,
+          { sourceId, targetId },
+        );
+
+        if (existsResult.records.length === 0) {
+          throw new RelationshipError(
+            'Source or target node not found',
+            sourceId,
+            targetId,
+            linkType,
+          );
+        }
+
+        // Nodes exist but have wrong labels
+        const sourceLabels = existsResult.records[0]?.sourceLabels || [];
+        const targetLabels = existsResult.records[0]?.targetLabels || [];
+        throw new RelationshipError(
+          `Invalid node types for ${linkType}: source has labels [${sourceLabels}], expected one of [${sourceLabelsClause}]; target has labels [${targetLabels}], expected one of [${targetLabelsClause}]`,
+          sourceId,
+          targetId,
+          linkType,
+        );
+      }
     } catch (error) {
+      // Re-throw RelationshipError as-is
+      if (error instanceof RelationshipError) {
+        throw error;
+      }
       throw new RelationshipError(
         'Failed to create cross-graph link',
         sourceId,

--- a/packages/server/src/mcp-server-factory.ts
+++ b/packages/server/src/mcp-server-factory.ts
@@ -284,6 +284,7 @@ function registerAddEventTool(
 
         // Link event to entities if specified
         const linkedEntities: string[] = [];
+        const failedLinks: Array<{ entity: string; reason: string }> = [];
         if (args.entities && Array.isArray(args.entities)) {
           for (const entityRef of args.entities) {
             try {
@@ -294,9 +295,16 @@ function registerAddEventTool(
                   entity.uuid,
                 );
                 linkedEntities.push(entity.name);
+              } else {
+                failedLinks.push({ entity: entityRef, reason: 'not found' });
               }
-            } catch {
-              // Entity not found - skip silently
+            } catch (err) {
+              const reason =
+                err instanceof Error ? err.message : 'unknown error';
+              failedLinks.push({ entity: entityRef, reason });
+              console.warn(
+                `[add_event] Failed to link entity "${entityRef}": ${reason}`,
+              );
             }
           }
         }
@@ -305,15 +313,19 @@ function registerAddEventTool(
           linkedEntities.length > 0
             ? ` (linked to: ${linkedEntities.join(', ')})`
             : '';
+        const failedText =
+          failedLinks.length > 0
+            ? ` (failed to link: ${failedLinks.map((f) => f.entity).join(', ')})`
+            : '';
 
         return {
           content: [
             {
               type: 'text' as const,
-              text: `Added event: ${event.description} at ${event.occurred_at.toISOString()}${linkedText}`,
+              text: `Added event: ${event.description} at ${event.occurred_at.toISOString()}${linkedText}${failedText}`,
             },
           ],
-          structuredContent: { ...event, linkedEntities },
+          structuredContent: { ...event, linkedEntities, failedLinks },
         };
       } catch (error) {
         return formatToolError(error, 'add_event');
@@ -350,28 +362,38 @@ function registerAddFactTool(
 
         // Link fact to subject entity if specified (creates X_INVOLVES relationship)
         let linkedEntity: string | undefined;
+        let linkError: string | undefined;
         if (args.subject_entity) {
           try {
             const entity = await graphs.entity.getEntity(args.subject_entity);
             if (entity) {
               await graphs.temporal.linkFactToEntity(fact.uuid, entity.uuid);
               linkedEntity = entity.name;
+            } else {
+              linkError = 'not found';
             }
-          } catch {
-            // Entity not found - skip silently
+          } catch (err) {
+            linkError = err instanceof Error ? err.message : 'unknown error';
+            console.warn(
+              `[add_fact] Failed to link entity "${args.subject_entity}": ${linkError}`,
+            );
           }
         }
 
         const linkedText = linkedEntity ? ` (about: ${linkedEntity})` : '';
+        const failedText =
+          linkError && args.subject_entity
+            ? ` (failed to link ${args.subject_entity}: ${linkError})`
+            : '';
 
         return {
           content: [
             {
               type: 'text' as const,
-              text: `Added fact: ${fact.subject} ${fact.predicate} ${fact.object}${linkedText}`,
+              text: `Added fact: ${fact.subject} ${fact.predicate} ${fact.object}${linkedText}${failedText}`,
             },
           ],
-          structuredContent: { ...fact, linkedEntity },
+          structuredContent: { ...fact, linkedEntity, linkError },
         };
       } catch (error) {
         return formatToolError(error, 'add_fact');
@@ -435,6 +457,7 @@ function registerAddCausalLinkTool(
 
         // Link causal nodes to entities if specified (creates X_AFFECTS relationships)
         const linkedEntities: string[] = [];
+        const failedEntityLinks: Array<{ entity: string; reason: string }> = [];
         if (args.entities && Array.isArray(args.entities)) {
           for (const entityRef of args.entities) {
             try {
@@ -444,15 +467,26 @@ function registerAddCausalLinkTool(
                 await graphs.causal.linkToEntity(causeNode.uuid, entity.uuid);
                 await graphs.causal.linkToEntity(effectNode.uuid, entity.uuid);
                 linkedEntities.push(entity.name);
+              } else {
+                failedEntityLinks.push({
+                  entity: entityRef,
+                  reason: 'not found',
+                });
               }
-            } catch {
-              // Entity not found - skip silently
+            } catch (err) {
+              const reason =
+                err instanceof Error ? err.message : 'unknown error';
+              failedEntityLinks.push({ entity: entityRef, reason });
+              console.warn(
+                `[add_causal_link] Failed to link entity "${entityRef}": ${reason}`,
+              );
             }
           }
         }
 
         // Link causal nodes to events if specified (creates X_REFERS_TO relationships)
         const linkedEvents: string[] = [];
+        const failedEventLinks: Array<{ event: string; reason: string }> = [];
         if (args.events && Array.isArray(args.events)) {
           for (const eventRef of args.events) {
             try {
@@ -466,9 +500,16 @@ function registerAddCausalLinkTool(
                     ? `${event.description.slice(0, 40)}...`
                     : event.description,
                 );
+              } else {
+                failedEventLinks.push({ event: eventRef, reason: 'not found' });
               }
-            } catch {
-              // Event not found - skip silently
+            } catch (err) {
+              const reason =
+                err instanceof Error ? err.message : 'unknown error';
+              failedEventLinks.push({ event: eventRef, reason });
+              console.warn(
+                `[add_causal_link] Failed to link event "${eventRef}": ${reason}`,
+              );
             }
           }
         }
@@ -481,14 +522,31 @@ function registerAddCausalLinkTool(
           linkedEvents.length > 0
             ? ` (refers to: ${linkedEvents.join(', ')})`
             : '';
+        const failedEntityText =
+          failedEntityLinks.length > 0
+            ? ` (failed entities: ${failedEntityLinks.map((f) => f.entity).join(', ')})`
+            : '';
+        const failedEventText =
+          failedEventLinks.length > 0
+            ? ` (failed events: ${failedEventLinks.map((f) => f.event).join(', ')})`
+            : '';
 
         return {
           content: [
             {
               type: 'text' as const,
-              text: `Added causal link: ${args.cause} -> ${args.effect}${args.confidence ? ` (confidence: ${args.confidence})` : ''}${linkedEntityText}${linkedEventText}`,
+              text: `Added causal link: ${args.cause} -> ${args.effect}${args.confidence ? ` (confidence: ${args.confidence})` : ''}${linkedEntityText}${linkedEventText}${failedEntityText}${failedEventText}`,
             },
           ],
+          structuredContent: {
+            cause: args.cause,
+            effect: args.effect,
+            confidence: args.confidence,
+            linkedEntities,
+            linkedEvents,
+            failedEntityLinks,
+            failedEventLinks,
+          },
         };
       } catch (error) {
         return formatToolError(error, 'add_causal_link');
@@ -518,6 +576,7 @@ function registerAddConceptTool(
 
         // Link concept to entities if specified (creates X_REPRESENTS relationships)
         const linkedEntities: string[] = [];
+        const failedLinks: Array<{ entity: string; reason: string }> = [];
         if (args.entities && Array.isArray(args.entities)) {
           for (const entityRef of args.entities) {
             try {
@@ -525,9 +584,16 @@ function registerAddConceptTool(
               if (entity) {
                 await graphs.semantic.linkToEntity(concept.uuid, entity.uuid);
                 linkedEntities.push(entity.name);
+              } else {
+                failedLinks.push({ entity: entityRef, reason: 'not found' });
               }
-            } catch {
-              // Entity not found - skip silently
+            } catch (err) {
+              const reason =
+                err instanceof Error ? err.message : 'unknown error';
+              failedLinks.push({ entity: entityRef, reason });
+              console.warn(
+                `[add_concept] Failed to link entity "${entityRef}": ${reason}`,
+              );
             }
           }
         }
@@ -536,12 +602,16 @@ function registerAddConceptTool(
           linkedEntities.length > 0
             ? ` (linked to: ${linkedEntities.join(', ')})`
             : '';
+        const failedText =
+          failedLinks.length > 0
+            ? ` (failed to link: ${failedLinks.map((f) => f.entity).join(', ')})`
+            : '';
 
         return {
           content: [
             {
               type: 'text' as const,
-              text: `Added concept: ${concept.name}${concept.description ? ` - ${concept.description}` : ''}${linkedText}`,
+              text: `Added concept: ${concept.name}${concept.description ? ` - ${concept.description}` : ''}${linkedText}${failedText}`,
             },
           ],
           structuredContent: {
@@ -549,6 +619,7 @@ function registerAddConceptTool(
             name: concept.name,
             description: concept.description,
             linkedEntities,
+            failedLinks,
           },
         };
       } catch (error) {


### PR DESCRIPTION
## Summary

Phase 3 Cross-Graph Linking fixes based on validate.md analysis:

- **Fix 5 silent catch blocks** in MCP tool handlers that were swallowing all errors
- **Add idempotent link creation** using MERGE to prevent duplicates
- **Add node type validation** to ensure correct labels for each X_ relationship type

## Changes

### MCP Tool Handlers (`mcp-server-factory.ts`)
- `add_event`: Track failed entity links, log errors, include in response
- `add_fact`: Track failed entity link, log errors, include in response  
- `add_causal_link`: Track failed entity/event links for both X_AFFECTS and X_REFERS_TO
- `add_concept`: Track failed entity links for X_REPRESENTS

### CrossLinker (`cross-linker.ts`)
- Use MERGE instead of CREATE for idempotent link creation
- Add label validation for each link type:
  - `X_REPRESENTS`: S_Concept → E_Entity
  - `X_INVOLVES`: T_Event|T_Fact → E_Entity
  - `X_AFFECTS`: C_Node → E_Entity
  - `X_REFERS_TO`: C_Node → T_Event
- Improved error messages distinguish "not found" from "wrong type"

## Test plan
- [x] All existing CrossLinker tests pass
- [x] Added new tests for idempotency, node validation, and error cases
- [x] Server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)