### PR TITLE
fix(mcp): improve protocol compliance with graceful degradation

### DIFF
--- a/packages/server/src/mcp-server-factory.ts
+++ b/packages/server/src/mcp-server-factory.ts
@@ -665,7 +665,8 @@ function registerSemanticSearchTool(
         const filtered = results.filter((r) => r.score >= min_score);
 
         // For each concept, fetch linked entity IDs via X_REPRESENTS
-        const matchesWithEntities = await Promise.all(
+        // Use Promise.allSettled for graceful degradation - one failure shouldn't kill all results
+        const settledResults = await Promise.allSettled(
           filtered.map(async (match) => {
             const linkedEntities = await db.query(
               `MATCH (c:S_Concept {uuid: $conceptId})-[:X_REPRESENTS]->(e:E_Entity)
@@ -685,6 +686,31 @@ function registerSemanticSearchTool(
             };
           }),
         );
+
+        // Extract successful results, log failures
+        const matchesWithEntities = settledResults
+          .filter(
+            (
+              result,
+            ): result is PromiseFulfilledResult<{
+              concept: { uuid: string; name: string; description?: string };
+              score: number;
+              linkedEntityIds: string[];
+              linkedEntityNames: string[];
+            }> => {
+              if (result.status === 'rejected') {
+                console.warn(
+                  '[semantic_search] Failed to fetch entity links for concept:',
+                  result.reason instanceof Error
+                    ? result.reason.message
+                    : String(result.reason),
+                );
+                return false;
+              }
+              return true;
+            },
+          )
+          .map((result) => result.value);
 
         // Collect all unique entity IDs for convenience
         const allEntityIds = [

--- a/packages/server/src/tools/management.ts
+++ b/packages/server/src/tools/management.ts
@@ -14,12 +14,3 @@ export const ClearGraphInputSchema = z.object({
 });
 
 export type ClearGraphInput = z.infer<typeof ClearGraphInputSchema>;
-
-/**
- * Schema for export_graph tool input (to be implemented)
- */
-export const ExportGraphInputSchema = z.object({
-  format: z.enum(['cypher', 'json']).describe('Export format'),
-});
-
-export type ExportGraphInput = z.infer<typeof ExportGraphInputSchema>;


### PR DESCRIPTION
## Summary

Section 9 fixes for MCP protocol compliance identified in the validation analysis.

### Fixed Issues

| # | Issue | Fix |
|---|-------|-----|
| 9.2 | `Promise.all()` in semantic_search - one failure kills all | Changed to `Promise.allSettled()` with graceful degradation |
| 9.dead | `ExportGraphInputSchema` unused | Removed dead code from management.ts |

### Behavior Change

Before: If any concept's entity lookup failed during `semantic_search`, the entire operation would fail.

After: Failed lookups are logged with `console.warn` and skipped. Successful results are still returned.

### Accepted Limitations

| # | Issue | Reason |
|---|-------|--------|
| 9.1 | Write tools skip validateToolInput() | Low risk - Zod schemas provide basic validation |
| 9.3-9.4 | No SSE/STDIO transport | Future enhancement |
| 9.5-9.9 | Various low priority items | Deferred |

## Test plan

- [x] All existing tests pass (`pnpm test`)
- [x] semantic_search returns partial results when some lookups fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)