### PR TITLE
perf: use Set for O(1) entity ID lookups in getRelationshipsBatch()

### DIFF
--- a/packages/core/src/graphs/entity.ts
+++ b/packages/core/src/graphs/entity.ts
@@ -341,6 +341,7 @@ export class EntityGraph {
 
       // Group relationships by entity UUID
       const relationshipMap = new Map<string, EntityRelationship[]>();
+      const entityIdSet = new Set(entityIds);
 
       // Initialize empty arrays for all requested entities
       for (const id of entityIds) {
@@ -359,14 +360,14 @@ export class EntityGraph {
         };
 
         // Add relationship to source entity's list if it's in our query
-        if (entityIds.includes(source.uuid)) {
+        if (entityIdSet.has(source.uuid)) {
           const sourceRels = relationshipMap.get(source.uuid) || [];
           sourceRels.push(relationship);
           relationshipMap.set(source.uuid, sourceRels);
         }
 
         // Add relationship to target entity's list if it's in our query
-        if (entityIds.includes(target.uuid)) {
+        if (entityIdSet.has(target.uuid)) {
           const targetRels = relationshipMap.get(target.uuid) || [];
           targetRels.push(relationship);
           relationshipMap.set(target.uuid, targetRels);


### PR DESCRIPTION
## Summary

- Replace `Array.includes()` with `Set.has()` for entity ID membership checks in `getRelationshipsBatch()`, reducing per-lookup complexity from O(n) to O(1)

Closes #51

## Test plan

- [ ] Verify existing entity graph tests pass
- [ ] No behavioral change — purely a performance optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)