### PR TITLE
fix: use temporal depth hints to scale time window

### DIFF
--- a/packages/core/src/executor/magma-executor.test.ts
+++ b/packages/core/src/executor/magma-executor.test.ts
@@ -518,6 +518,59 @@ describe('MAGMAExecutor', () => {
         expect(result.merged.viewContributions.temporal).toBe(2);
       });
 
+      it('should scale temporal time window by depth hint', async () => {
+        const graphs = createMockGraphs({
+          enrichedResults: [
+            createEnrichedSemanticMatch(
+              'concept1',
+              0.9,
+              ['entity1'],
+              ['Entity 1'],
+            ),
+          ],
+          temporalEvents: {
+            entity1: [
+              {
+                uuid: 'event1',
+                description: 'Test event',
+                occurred_at: new Date(),
+              },
+            ],
+          },
+        });
+
+        const executor = new MAGMAExecutor(graphs);
+
+        // Execute with depth 1 (should use ±3 months)
+        const intentDepth1 = createValidIntent('WHEN', {
+          depthHints: { entity: 1, temporal: 1, causal: 1 },
+        });
+        await executor.execute('when did this happen?', intentDepth1);
+
+        const call1Args = vi.mocked(graphs.temporal.queryTimelineForEntities)
+          .mock.calls[0];
+        const from1 = call1Args[1] as Date;
+        const to1 = call1Args[2] as Date;
+        const range1Ms = to1.getTime() - from1.getTime();
+
+        vi.mocked(graphs.temporal.queryTimelineForEntities).mockClear();
+
+        // Execute with depth 5 (should use ±15 months)
+        const intentDepth5 = createValidIntent('WHEN', {
+          depthHints: { entity: 1, temporal: 5, causal: 1 },
+        });
+        await executor.execute('when did this happen?', intentDepth5);
+
+        const call5Args = vi.mocked(graphs.temporal.queryTimelineForEntities)
+          .mock.calls[0];
+        const from5 = call5Args[1] as Date;
+        const to5 = call5Args[2] as Date;
+        const range5Ms = to5.getTime() - from5.getTime();
+
+        // Depth 5 should produce a time range 5x wider than depth 1
+        expect(range5Ms).toBeCloseTo(range1Ms * 5, -3);
+      });
+
       it('should handle entities with no temporal events', async () => {
         const graphs = createMockGraphs({
           enrichedResults: [

--- a/packages/core/src/executor/magma-executor.ts
+++ b/packages/core/src/executor/magma-executor.ts
@@ -374,15 +374,17 @@ export class MAGMAExecutor {
    */
   private async expandTemporalGraph(
     entityIds: string[],
-    _depth: number,
+    depth: number,
   ): Promise<GraphView> {
     const nodes: GraphView['nodes'] = [];
     const seenIds = new Set<string>();
 
-    // Use a wide time range (last year to now + 1 year)
+    // Scale time window by depth hint: each depth unit = 3 months
+    // depth 1 → ±3 months, depth 2 → ±6 months, ..., depth 5 → ±15 months
     const now = new Date();
-    const from = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000);
-    const to = new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000);
+    const msPerDepthUnit = 90 * 24 * 60 * 60 * 1000; // ~3 months
+    const from = new Date(now.getTime() - depth * msPerDepthUnit);
+    const to = new Date(now.getTime() + depth * msPerDepthUnit);
 
     // Single batch query for all entities
     // Errors propagate up for graceful degradation at Promise.allSettled level


### PR DESCRIPTION
## Summary

- Replace hardcoded ±1 year time window in `expandTemporalGraph()` with a depth-scaled window: each depth unit = ~3 months
- `_depth` parameter is now used (renamed to `depth`), so `depthHints.temporal` from the intent classifier actually influences the query range
- depth 1 → ±3 months, depth 2 → ±6 months, ..., depth 5 → ±15 months

Closes #56

## Test plan

- [x] New test: `should scale temporal time window by depth hint` — verifies depth 5 produces a 5x wider window than depth 1
- [x] All 40 executor tests pass
- [x] Lint clean (biome)
- [x] Type check clean (tsc --noEmit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)