### PR TITLE
feat: ingestion fast + slow path — core runtime

### DIFF
--- a/packages/core/src/ingestion/extraction-prompt.test.ts
+++ b/packages/core/src/ingestion/extraction-prompt.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildExtractionPrompt,
+  formatNeighborhoodSummary,
+} from './extraction-prompt.js';
+import type { NeighborhoodContext } from './neighborhood.js';
+import type { DocumentProfile, ParsedChunk } from './types.js';
+
+const testProfile: DocumentProfile = {
+  document_type: 'conversation',
+  domain: 'general',
+  entity_types_expected: ['person', 'place', 'organization'],
+  relationship_types_expected: ['knows', 'works_at'],
+  causal_patterns: ['decision → action', 'event → reaction'],
+  temporal_structure: 'session_ordered',
+  extraction_focus: 'Focus on people and their relationships.',
+  confidence_calibration: {
+    explicit_causation: 1.0,
+    strong_implication: 0.85,
+    weak_inference: 0.65,
+  },
+};
+
+const testChunk: ParsedChunk = {
+  chunk_id: 'chunk_003',
+  content: 'Alice: I just started working at Acme Corp last week.',
+  position: 3,
+  metadata: {
+    source_format: 'conversation',
+    speaker: 'Alice',
+    turn_index: 3,
+  },
+};
+
+const emptyNeighborhood: NeighborhoodContext = {
+  knownEntities: [],
+  recentEvents: [],
+  activeCausalChains: [],
+  similarConcepts: [],
+};
+
+const richNeighborhood: NeighborhoodContext = {
+  knownEntities: [
+    { name: 'Alice', type: 'person', uuid: 'uuid-1' },
+    { name: 'Acme Corp', type: 'organization', uuid: 'uuid-2' },
+  ],
+  recentEvents: [
+    {
+      description: 'Alice mentioned job search',
+      occurred_at: '2024-01-15T10:00:00Z',
+    },
+  ],
+  activeCausalChains: [
+    { cause: 'Job search', effect: 'Got hired', confidence: 0.9 },
+  ],
+  similarConcepts: [
+    { name: 'Employment', score: 0.85 },
+    { name: 'Career change', score: 0.72 },
+  ],
+};
+
+describe('buildExtractionPrompt', () => {
+  describe('system prompt', () => {
+    it('should include document type and domain', () => {
+      const { system } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+      );
+      expect(system).toContain('Document type: conversation');
+      expect(system).toContain('Domain: general');
+    });
+
+    it('should include entity types', () => {
+      const { system } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+      );
+      expect(system).toContain('person, place, organization');
+    });
+
+    it('should include relationship types', () => {
+      const { system } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+      );
+      expect(system).toContain('knows, works_at');
+    });
+
+    it('should include causal patterns', () => {
+      const { system } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+      );
+      expect(system).toContain('decision → action');
+      expect(system).toContain('event → reaction');
+    });
+
+    it('should include confidence calibration', () => {
+      const { system } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+      );
+      expect(system).toContain('Explicit causation');
+      expect(system).toContain('1');
+      expect(system).toContain('0.85');
+      expect(system).toContain('0.65');
+    });
+
+    it('should include extraction focus', () => {
+      const { system } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+      );
+      expect(system).toContain('Focus on people and their relationships.');
+    });
+
+    it('should include JSON output format', () => {
+      const { system } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+      );
+      expect(system).toContain('"entities"');
+      expect(system).toContain('"relationships"');
+      expect(system).toContain('"causal_links"');
+      expect(system).toContain('"facts"');
+    });
+
+    it('should include entity reuse directive', () => {
+      const { system } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+      );
+      expect(system).toContain('REUSE the exact same name');
+    });
+  });
+
+  describe('user prompt', () => {
+    it('should include chunk content', () => {
+      const { user } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+      );
+      expect(user).toContain(
+        'Alice: I just started working at Acme Corp last week.',
+      );
+    });
+
+    it('should not include context section when neighborhood is empty', () => {
+      const { user } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+      );
+      expect(user).not.toContain('Context from existing graph');
+      expect(user).not.toContain('Known entities');
+    });
+
+    it('should include known entities when available', () => {
+      const { user } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        richNeighborhood,
+      );
+      expect(user).toContain(
+        'Known entities: Alice (person), Acme Corp (organization)',
+      );
+    });
+
+    it('should include recent events when available', () => {
+      const { user } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        richNeighborhood,
+      );
+      expect(user).toContain('Recent events: Alice mentioned job search');
+    });
+
+    it('should include causal chains when available', () => {
+      const { user } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        richNeighborhood,
+      );
+      expect(user).toContain(
+        'Active causal chains: Job search → Got hired (0.9)',
+      );
+    });
+
+    it('should include similar concepts when available', () => {
+      const { user } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        richNeighborhood,
+      );
+      expect(user).toContain('Related concepts: Employment, Career change');
+    });
+  });
+});
+
+describe('formatNeighborhoodSummary', () => {
+  it('should return empty summary for empty neighborhood', () => {
+    expect(formatNeighborhoodSummary(emptyNeighborhood)).toBe(
+      '(empty neighborhood)',
+    );
+  });
+
+  it('should format rich neighborhood', () => {
+    const summary = formatNeighborhoodSummary(richNeighborhood);
+    expect(summary).toContain('Entities(2)');
+    expect(summary).toContain('Events(1)');
+    expect(summary).toContain('Causal(1)');
+    expect(summary).toContain('Concepts(2)');
+  });
+});

--- a/packages/core/src/ingestion/extraction-prompt.ts
+++ b/packages/core/src/ingestion/extraction-prompt.ts
@@ -1,0 +1,134 @@
+// Per-chunk LLM extraction prompt builder
+
+import type { NeighborhoodContext } from './neighborhood.js';
+import type { DocumentProfile, ParsedChunk } from './types.js';
+
+/**
+ * Build the LLM prompt for per-chunk knowledge extraction.
+ *
+ * The system prompt encodes the document profile (domain, entity types,
+ * causal patterns, confidence calibration). The user prompt includes
+ * the chunk text plus formatted neighborhood context for entity reuse.
+ */
+export function buildExtractionPrompt(
+  chunk: ParsedChunk,
+  profile: DocumentProfile,
+  neighborhood: NeighborhoodContext,
+): { system: string; user: string } {
+  const system = buildSystemPrompt(profile);
+  const user = buildUserPrompt(chunk, neighborhood);
+  return { system, user };
+}
+
+function buildSystemPrompt(profile: DocumentProfile): string {
+  const lines: string[] = [
+    'You are a structured data extraction system. Given a chunk of a document, extract structured graph data as JSON.',
+    '',
+    `Document type: ${profile.document_type}`,
+    `Domain: ${profile.domain}`,
+    '',
+    `Entity types to look for: ${profile.entity_types_expected.join(', ')}`,
+    `Relationship types expected: ${profile.relationship_types_expected.join(', ')}`,
+    '',
+    `Causal patterns to detect: ${profile.causal_patterns.join('; ')}`,
+    '',
+    `Extraction focus: ${profile.extraction_focus}`,
+    '',
+    'Confidence calibration:',
+    `- Explicit causation (stated directly): ${profile.confidence_calibration.explicit_causation}`,
+    `- Strong implication (clearly implied): ${profile.confidence_calibration.strong_implication}`,
+    `- Weak inference (loosely suggested): ${profile.confidence_calibration.weak_inference}`,
+    '',
+    'IMPORTANT: When you see entities that match known entity names listed below, REUSE the exact same name to maintain graph consistency.',
+    '',
+    'Output ONLY valid JSON matching this exact structure:',
+    '{',
+    '  "entities": [{ "name": string, "entity_type": string, "properties"?: { ... } }],',
+    '  "relationships": [{ "source": entity_name, "target": entity_name, "relationship_type": string }],',
+    '  "causal_links": [{ "cause": string, "effect": string, "confidence": 0.0-1.0, "evidence"?: string, "entities"?: [names] }],',
+    '  "facts": [{ "subject": string, "predicate": string, "object": string, "valid_from": ISO8601, "valid_to"?: ISO8601, "subject_entity"?: entity_name }]',
+    '}',
+    '',
+    'Be thorough but precise. Do not hallucinate information not present in the text.',
+  ];
+
+  return lines.join('\n');
+}
+
+function buildUserPrompt(
+  chunk: ParsedChunk,
+  neighborhood: NeighborhoodContext,
+): string {
+  const sections: string[] = [];
+
+  // Neighborhood context
+  if (neighborhood.knownEntities.length > 0) {
+    const entityList = neighborhood.knownEntities
+      .map((e) => `${e.name} (${e.type})`)
+      .join(', ');
+    sections.push(`Known entities: ${entityList}`);
+  }
+
+  if (neighborhood.recentEvents.length > 0) {
+    const eventList = neighborhood.recentEvents
+      .map((e) => e.description)
+      .join('; ');
+    sections.push(`Recent events: ${eventList}`);
+  }
+
+  if (neighborhood.activeCausalChains.length > 0) {
+    const chainList = neighborhood.activeCausalChains
+      .map((c) => `${c.cause} → ${c.effect} (${c.confidence})`)
+      .join('; ');
+    sections.push(`Active causal chains: ${chainList}`);
+  }
+
+  if (neighborhood.similarConcepts.length > 0) {
+    const conceptList = neighborhood.similarConcepts
+      .map((c) => c.name)
+      .join(', ');
+    sections.push(`Related concepts: ${conceptList}`);
+  }
+
+  // Build user prompt
+  const parts: string[] = [];
+
+  if (sections.length > 0) {
+    parts.push('Context from existing graph:');
+    parts.push(...sections);
+    parts.push('');
+  }
+
+  parts.push('Extract structured data from this text:');
+  parts.push('');
+  parts.push(chunk.content);
+
+  return parts.join('\n');
+}
+
+/**
+ * Format neighborhood context as a plain string summary.
+ * Useful for debugging or logging.
+ */
+export function formatNeighborhoodSummary(
+  neighborhood: NeighborhoodContext,
+): string {
+  const parts: string[] = [];
+
+  if (neighborhood.knownEntities.length > 0) {
+    parts.push(
+      `Entities(${neighborhood.knownEntities.length}): ${neighborhood.knownEntities.map((e) => e.name).join(', ')}`,
+    );
+  }
+  if (neighborhood.recentEvents.length > 0) {
+    parts.push(`Events(${neighborhood.recentEvents.length})`);
+  }
+  if (neighborhood.activeCausalChains.length > 0) {
+    parts.push(`Causal(${neighborhood.activeCausalChains.length})`);
+  }
+  if (neighborhood.similarConcepts.length > 0) {
+    parts.push(`Concepts(${neighborhood.similarConcepts.length})`);
+  }
+
+  return parts.length > 0 ? parts.join(' | ') : '(empty neighborhood)';
+}

--- a/packages/core/src/ingestion/fast-path.test.ts
+++ b/packages/core/src/ingestion/fast-path.test.ts
@@ -1,0 +1,160 @@
+import type { EmbeddingProvider } from '@polyg-mcp/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FalkorDBAdapter } from '../storage/falkordb.js';
+import { runFastPath } from './fast-path.js';
+import type { IngestionDeps, ParsedChunk } from './types.js';
+
+function createMockDb(): FalkorDBAdapter {
+  let nodeCounter = 0;
+  return {
+    query: vi.fn().mockResolvedValue({ records: [], metadata: [] }),
+    createNode: vi.fn().mockImplementation(() => {
+      nodeCounter++;
+      return Promise.resolve(`uuid-${nodeCounter}`);
+    }),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  } as unknown as FalkorDBAdapter;
+}
+
+function createMockEmbeddings(): EmbeddingProvider {
+  return {
+    embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+    embedBatch: vi
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map((_, i) => [0.1 * (i + 1), 0.2 * (i + 1)])),
+      ),
+  };
+}
+
+function makeChunks(count: number): ParsedChunk[] {
+  return Array.from({ length: count }, (_, i) => ({
+    chunk_id: `chunk_${i.toString().padStart(3, '0')}`,
+    content: `Message content ${i}`,
+    position: i,
+    metadata: {
+      source_format: 'conversation' as const,
+      speaker: i % 2 === 0 ? 'Alice' : 'Bob',
+      turn_index: i,
+      ...(i === 0 ? { timestamp: '2024-01-15T10:00:00Z' } : {}),
+    },
+  }));
+}
+
+describe('runFastPath', () => {
+  let db: FalkorDBAdapter;
+  let embeddings: EmbeddingProvider;
+  let deps: IngestionDeps;
+
+  beforeEach(() => {
+    db = createMockDb();
+    embeddings = createMockEmbeddings();
+    deps = {
+      db,
+      embeddings,
+      llm: { complete: vi.fn() },
+    } as unknown as IngestionDeps;
+    vi.clearAllMocks();
+  });
+
+  it('should call embedBatch once with all chunk texts', async () => {
+    const chunks = makeChunks(5);
+    // Re-create db to reset counter
+    db = createMockDb();
+    deps.db = db;
+
+    await runFastPath(chunks, deps);
+
+    expect(embeddings.embedBatch).toHaveBeenCalledTimes(1);
+    expect(embeddings.embedBatch).toHaveBeenCalledWith(
+      chunks.map((c) => c.content.slice(0, 200)),
+    );
+  });
+
+  it('should create T_Event and S_Concept for each chunk', async () => {
+    const chunks = makeChunks(3);
+    db = createMockDb();
+    deps.db = db;
+
+    const result = await runFastPath(chunks, deps);
+
+    // Each chunk creates 2 nodes: 1 T_Event + 1 S_Concept = 6 total
+    expect(db.createNode).toHaveBeenCalledTimes(6);
+    expect(result.eventIds).toHaveLength(3);
+    expect(result.conceptIds).toHaveLength(3);
+  });
+
+  it('should create FOLLOWS edges for temporal backbone', async () => {
+    const chunks = makeChunks(3);
+    db = createMockDb();
+    deps.db = db;
+
+    await runFastPath(chunks, deps);
+
+    // 3 chunks → 2 FOLLOWS edges (between consecutive events)
+    // Plus: 3 getConceptByName queries (dedup checks) + 2 FOLLOWS MERGE queries
+    const queryCalls = vi.mocked(db.query).mock.calls;
+    const followsQueries = queryCalls.filter(
+      ([cypher]) => typeof cypher === 'string' && cypher.includes('FOLLOWS'),
+    );
+    expect(followsQueries).toHaveLength(2);
+  });
+
+  it('should return timing information', async () => {
+    const chunks = makeChunks(2);
+    db = createMockDb();
+    deps.db = db;
+
+    const result = await runFastPath(chunks, deps);
+
+    expect(result.embeddingTimeMs).toBeGreaterThanOrEqual(0);
+    expect(result.writeTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should handle empty chunk list', async () => {
+    const result = await runFastPath([], deps);
+
+    expect(result.eventIds).toHaveLength(0);
+    expect(result.conceptIds).toHaveLength(0);
+    expect(embeddings.embedBatch).toHaveBeenCalledWith([]);
+  });
+
+  it('should use chunk timestamp for event occurred_at when available', async () => {
+    const chunks = makeChunks(1);
+    chunks[0].metadata.timestamp = '2024-06-15T14:30:00Z';
+    db = createMockDb();
+    deps.db = db;
+
+    await runFastPath(chunks, deps);
+
+    // First createNode call should be for T_Event with the timestamp
+    const createCalls = vi.mocked(db.createNode).mock.calls;
+    const eventCall = createCalls.find(([label]) => label === 'T_Event');
+    expect(eventCall).toBeDefined();
+    expect(eventCall?.[1].occurred_at).toBe('2024-06-15T14:30:00.000Z');
+  });
+
+  it('should truncate content for concept name and description', async () => {
+    const longContent = 'A'.repeat(600);
+    const chunks: ParsedChunk[] = [
+      {
+        chunk_id: 'chunk_000',
+        content: longContent,
+        position: 0,
+        metadata: { source_format: 'conversation' },
+      },
+    ];
+    db = createMockDb();
+    deps.db = db;
+
+    await runFastPath(chunks, deps);
+
+    // S_Concept createNode: name should be truncated to 100 chars
+    const createCalls = vi.mocked(db.createNode).mock.calls;
+    const conceptCall = createCalls.find(([label]) => label === 'S_Concept');
+    expect(conceptCall).toBeDefined();
+    expect((conceptCall?.[1].name as string).length).toBe(100);
+    expect((conceptCall?.[1].description as string).length).toBe(500);
+  });
+});

--- a/packages/core/src/ingestion/fast-path.test.ts
+++ b/packages/core/src/ingestion/fast-path.test.ts
@@ -1,7 +1,7 @@
 import type { EmbeddingProvider } from '@polyg-mcp/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { FalkorDBAdapter } from '../storage/falkordb.js';
-import { runFastPath } from './fast-path.js';
+import { EMBED_TEXT_LIMIT, runFastPath } from './fast-path.js';
 import type { IngestionDeps, ParsedChunk } from './types.js';
 
 function createMockDb(): FalkorDBAdapter {
@@ -68,7 +68,7 @@ describe('runFastPath', () => {
 
     expect(embeddings.embedBatch).toHaveBeenCalledTimes(1);
     expect(embeddings.embedBatch).toHaveBeenCalledWith(
-      chunks.map((c) => c.content.slice(0, 200)),
+      chunks.map((c) => c.content.slice(0, EMBED_TEXT_LIMIT)),
     );
   });
 
@@ -133,6 +133,98 @@ describe('runFastPath', () => {
     const eventCall = createCalls.find(([label]) => label === 'T_Event');
     if (!eventCall) throw new Error('eventCall not found');
     expect(eventCall[1].occurred_at).toBe('2024-06-15T14:30:00.000Z');
+  });
+
+  it('should use synthetic timestamps for chunks without real ones', async () => {
+    // chunk 0 has a timestamp, chunks 1-2 do not
+    const chunks: ParsedChunk[] = [
+      {
+        chunk_id: 'chunk_000',
+        content: 'First message',
+        position: 0,
+        metadata: {
+          source_format: 'conversation',
+          timestamp: '2024-01-15T10:00:00Z',
+        },
+      },
+      {
+        chunk_id: 'chunk_001',
+        content: 'Second message',
+        position: 1,
+        metadata: { source_format: 'conversation' },
+      },
+      {
+        chunk_id: 'chunk_002',
+        content: 'Third message',
+        position: 2,
+        metadata: { source_format: 'conversation' },
+      },
+    ];
+    db = createMockDb();
+    deps.db = db;
+
+    await runFastPath(chunks, deps);
+
+    const createCalls = vi.mocked(db.createNode).mock.calls;
+    const eventCalls = createCalls.filter(([label]) => label === 'T_Event');
+    expect(eventCalls).toHaveLength(3);
+
+    // chunk 0: real timestamp
+    expect(eventCalls[0][1].occurred_at).toBe('2024-01-15T10:00:00.000Z');
+    // chunk 1: base + 1 * 60_000ms = 1 minute after base
+    const base = new Date('2024-01-15T10:00:00Z').getTime();
+    expect(eventCalls[1][1].occurred_at).toBe(
+      new Date(base + 1 * 60_000).toISOString(),
+    );
+    // chunk 2: base + 2 * 60_000ms = 2 minutes after base
+    expect(eventCalls[2][1].occurred_at).toBe(
+      new Date(base + 2 * 60_000).toISOString(),
+    );
+  });
+
+  it('should offset base time when first timestamp is mid-array', async () => {
+    // chunk 0-1 have no timestamp, chunk 2 has one
+    const chunks: ParsedChunk[] = [
+      {
+        chunk_id: 'chunk_000',
+        content: 'First',
+        position: 0,
+        metadata: { source_format: 'conversation' },
+      },
+      {
+        chunk_id: 'chunk_001',
+        content: 'Second',
+        position: 1,
+        metadata: { source_format: 'conversation' },
+      },
+      {
+        chunk_id: 'chunk_002',
+        content: 'Third',
+        position: 2,
+        metadata: {
+          source_format: 'conversation',
+          timestamp: '2024-01-15T10:02:00Z',
+        },
+      },
+    ];
+    db = createMockDb();
+    deps.db = db;
+
+    await runFastPath(chunks, deps);
+
+    const createCalls = vi.mocked(db.createNode).mock.calls;
+    const eventCalls = createCalls.filter(([label]) => label === 'T_Event');
+
+    // base = chunk2 timestamp - 2*60s = 10:00:00
+    const base = new Date('2024-01-15T10:02:00Z').getTime() - 2 * 60_000;
+    // chunk 0: base + 0 = 10:00:00 (before chunk 2)
+    expect(eventCalls[0][1].occurred_at).toBe(new Date(base).toISOString());
+    // chunk 1: base + 60s = 10:01:00 (before chunk 2)
+    expect(eventCalls[1][1].occurred_at).toBe(
+      new Date(base + 60_000).toISOString(),
+    );
+    // chunk 2: real timestamp
+    expect(eventCalls[2][1].occurred_at).toBe('2024-01-15T10:02:00.000Z');
   });
 
   it('should truncate content for concept name and description', async () => {

--- a/packages/core/src/ingestion/fast-path.test.ts
+++ b/packages/core/src/ingestion/fast-path.test.ts
@@ -131,8 +131,8 @@ describe('runFastPath', () => {
     // First createNode call should be for T_Event with the timestamp
     const createCalls = vi.mocked(db.createNode).mock.calls;
     const eventCall = createCalls.find(([label]) => label === 'T_Event');
-    expect(eventCall).toBeDefined();
-    expect(eventCall?.[1].occurred_at).toBe('2024-06-15T14:30:00.000Z');
+    if (!eventCall) throw new Error('eventCall not found');
+    expect(eventCall[1].occurred_at).toBe('2024-06-15T14:30:00.000Z');
   });
 
   it('should truncate content for concept name and description', async () => {
@@ -153,8 +153,8 @@ describe('runFastPath', () => {
     // S_Concept createNode: name should be truncated to 100 chars
     const createCalls = vi.mocked(db.createNode).mock.calls;
     const conceptCall = createCalls.find(([label]) => label === 'S_Concept');
-    expect(conceptCall).toBeDefined();
-    expect((conceptCall?.[1].name as string).length).toBe(100);
-    expect((conceptCall?.[1].description as string).length).toBe(500);
+    if (!conceptCall) throw new Error('conceptCall not found');
+    expect((conceptCall[1].name as string).length).toBe(100);
+    expect((conceptCall[1].description as string).length).toBe(500);
   });
 });

--- a/packages/core/src/ingestion/fast-path.ts
+++ b/packages/core/src/ingestion/fast-path.ts
@@ -3,6 +3,15 @@ import { SemanticGraph } from '../graphs/semantic.js';
 import { TemporalGraph } from '../graphs/temporal.js';
 import type { FastPathResult, IngestionDeps, ParsedChunk } from './types.js';
 
+/** Max chars sent to the embedding model per chunk. */
+export const EMBED_TEXT_LIMIT = 500;
+/** Max chars for S_Concept node name. */
+export const CONCEPT_NAME_LIMIT = 100;
+/** Max chars for S_Concept node description. */
+export const CONCEPT_DESC_LIMIT = 500;
+/** Interval (ms) between synthetic timestamps for chunks without real ones. */
+const SYNTHETIC_INTERVAL_MS = 60_000;
+
 /**
  * Run the fast path: batch embed all chunks, then sequentially write
  * T_Event + S_Concept nodes with a temporal backbone (FOLLOWS edges).
@@ -18,7 +27,7 @@ export async function runFastPath(
 
   // Phase A: Batch embed all chunk content in a single API call
   const t0 = Date.now();
-  const texts = chunks.map((c) => c.content.slice(0, 200));
+  const texts = chunks.map((c) => c.content.slice(0, EMBED_TEXT_LIMIT));
   const embeddings = await deps.embeddings.embedBatch(texts);
   const embeddingTimeMs = Date.now() - t0;
 
@@ -27,6 +36,7 @@ export async function runFastPath(
   const eventIds: string[] = [];
   const conceptIds: string[] = [];
   let previousEventId: string | null = null;
+  const baseTime = resolveBaseTime(chunks);
 
   for (let i = 0; i < chunks.length; i++) {
     const chunk = chunks[i];
@@ -34,15 +44,15 @@ export async function runFastPath(
     // 1. Create T_Event
     const occurredAt = chunk.metadata.timestamp
       ? new Date(chunk.metadata.timestamp)
-      : new Date();
+      : new Date(baseTime + i * SYNTHETIC_INTERVAL_MS);
     const event = await temporal.addEvent(chunk.content, occurredAt);
     eventIds.push(event.uuid);
 
     // 2. Create S_Concept with pre-computed embedding
     const concept = await semantic.addConceptWithEmbedding(
-      chunk.content.slice(0, 100), // name: truncated
+      chunk.content.slice(0, CONCEPT_NAME_LIMIT),
       embeddings[i],
-      chunk.content.slice(0, 500), // description: longer context
+      chunk.content.slice(0, CONCEPT_DESC_LIMIT),
     );
     conceptIds.push(concept.uuid);
 
@@ -59,4 +69,29 @@ export async function runFastPath(
     embeddingTimeMs,
     writeTimeMs: Date.now() - t1,
   };
+}
+
+/**
+ * Resolve a base time for synthetic timestamps.
+ * Finds the first chunk with a real timestamp and offsets backwards so that
+ * chunk 0 starts at `timestamp - (index * interval)`. If no chunk has a
+ * timestamp, falls back to Date.now().
+ *
+ * Known gap: when multiple chunks have real timestamps scattered throughout
+ * (e.g. chunk 0 at 10:00, chunk 5 at 10:02), synthetic chunks between them
+ * may have occurred_at values that break chronological order relative to later
+ * real timestamps. FOLLOWS edges still preserve correct positional order.
+ * This doesn't affect current parsers (conversation = all timestamps or none),
+ * but would need interpolation logic if a future parser produces mixed output.
+ */
+function resolveBaseTime(chunks: ParsedChunk[]): number {
+  for (let i = 0; i < chunks.length; i++) {
+    if (chunks[i].metadata.timestamp) {
+      return (
+        new Date(chunks[i].metadata.timestamp as string).getTime() -
+        i * SYNTHETIC_INTERVAL_MS
+      );
+    }
+  }
+  return Date.now();
 }

--- a/packages/core/src/ingestion/fast-path.ts
+++ b/packages/core/src/ingestion/fast-path.ts
@@ -1,0 +1,62 @@
+// Fast path — batch embed + sequential graph write
+import { SemanticGraph } from '../graphs/semantic.js';
+import { TemporalGraph } from '../graphs/temporal.js';
+import type { FastPathResult, IngestionDeps, ParsedChunk } from './types.js';
+
+/**
+ * Run the fast path: batch embed all chunks, then sequentially write
+ * T_Event + S_Concept nodes with a temporal backbone (FOLLOWS edges).
+ *
+ * This creates the structural skeleton that the slow path enriches.
+ */
+export async function runFastPath(
+  chunks: ParsedChunk[],
+  deps: IngestionDeps,
+): Promise<FastPathResult> {
+  const semantic = new SemanticGraph(deps.db, deps.embeddings);
+  const temporal = new TemporalGraph(deps.db);
+
+  // Phase A: Batch embed all chunk content in a single API call
+  const t0 = Date.now();
+  const texts = chunks.map((c) => c.content.slice(0, 200));
+  const embeddings = await deps.embeddings.embedBatch(texts);
+  const embeddingTimeMs = Date.now() - t0;
+
+  // Phase B: Sequential write — events, concepts, temporal backbone
+  const t1 = Date.now();
+  const eventIds: string[] = [];
+  const conceptIds: string[] = [];
+  let previousEventId: string | null = null;
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+
+    // 1. Create T_Event
+    const occurredAt = chunk.metadata.timestamp
+      ? new Date(chunk.metadata.timestamp)
+      : new Date();
+    const event = await temporal.addEvent(chunk.content, occurredAt);
+    eventIds.push(event.uuid);
+
+    // 2. Create S_Concept with pre-computed embedding
+    const concept = await semantic.addConceptWithEmbedding(
+      chunk.content.slice(0, 100), // name: truncated
+      embeddings[i],
+      chunk.content.slice(0, 500), // description: longer context
+    );
+    conceptIds.push(concept.uuid);
+
+    // 3. Temporal backbone: chain events with FOLLOWS edges
+    if (previousEventId) {
+      await temporal.linkEventsSequentially(previousEventId, event.uuid);
+    }
+    previousEventId = event.uuid;
+  }
+
+  return {
+    eventIds,
+    conceptIds,
+    embeddingTimeMs,
+    writeTimeMs: Date.now() - t1,
+  };
+}

--- a/packages/core/src/ingestion/neighborhood.test.ts
+++ b/packages/core/src/ingestion/neighborhood.test.ts
@@ -1,0 +1,183 @@
+import type { EmbeddingProvider } from '@polyg-mcp/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FalkorDBAdapter } from '../storage/falkordb.js';
+import { gather2HopNeighborhood } from './neighborhood.js';
+import type { IngestionDeps } from './types.js';
+
+function createMockDb(): FalkorDBAdapter {
+  return {
+    query: vi.fn().mockResolvedValue({ records: [], metadata: [] }),
+    createNode: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  } as unknown as FalkorDBAdapter;
+}
+
+function createMockEmbeddings(): EmbeddingProvider {
+  return {
+    embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+    embedBatch: vi.fn().mockResolvedValue([[0.1, 0.2, 0.3]]),
+  };
+}
+
+describe('gather2HopNeighborhood', () => {
+  let db: FalkorDBAdapter;
+  let deps: IngestionDeps;
+
+  beforeEach(() => {
+    db = createMockDb();
+    deps = {
+      db,
+      embeddings: createMockEmbeddings(),
+      llm: { complete: vi.fn() },
+    } as unknown as IngestionDeps;
+    vi.clearAllMocks();
+  });
+
+  it('should return empty neighborhood when no recent events exist', async () => {
+    const result = await gather2HopNeighborhood(
+      'event-1',
+      'concept-1',
+      deps,
+      [],
+      0,
+    );
+
+    expect(result.knownEntities).toHaveLength(0);
+    expect(result.recentEvents).toHaveLength(0);
+    expect(result.activeCausalChains).toHaveLength(0);
+    expect(result.similarConcepts).toHaveLength(0);
+  });
+
+  it('should window to previous 5 events', async () => {
+    const eventIds = Array.from({ length: 10 }, (_, i) => `event-${i}`);
+
+    await gather2HopNeighborhood('event-7', 'concept-7', deps, eventIds, 7);
+
+    // Should query with event IDs from position 2 through 7 (6 events)
+    const queryCalls = vi.mocked(db.query).mock.calls;
+    // First call is for known entities
+    const entityQuery = queryCalls.find(
+      ([cypher]) => typeof cypher === 'string' && cypher.includes('X_INVOLVES'),
+    );
+    expect(entityQuery).toBeDefined();
+    const passedIds = entityQuery?.[1].eventIds as string[];
+    expect(passedIds).toHaveLength(6); // positions 2-7
+    expect(passedIds[0]).toBe('event-2');
+    expect(passedIds[5]).toBe('event-7');
+  });
+
+  it('should handle position 0 gracefully', async () => {
+    const eventIds = ['event-0'];
+
+    const result = await gather2HopNeighborhood(
+      'event-0',
+      'concept-0',
+      deps,
+      eventIds,
+      0,
+    );
+
+    // Should still work with just the current event
+    expect(result).toBeDefined();
+    expect(result.knownEntities).toHaveLength(0);
+  });
+
+  it('should return entities from DB query', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('X_INVOLVES') &&
+        cypher.includes('E_RELATES')
+      ) {
+        return {
+          records: [
+            { uuid: 'ent-1', name: 'Alice', type: 'person' },
+            { uuid: 'ent-2', name: 'Acme Corp', type: 'organization' },
+          ],
+          metadata: [],
+        };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const result = await gather2HopNeighborhood(
+      'event-0',
+      'concept-0',
+      deps,
+      ['event-0'],
+      0,
+    );
+
+    expect(result.knownEntities).toHaveLength(2);
+    expect(result.knownEntities[0].name).toBe('Alice');
+    expect(result.knownEntities[1].name).toBe('Acme Corp');
+  });
+
+  it('should return recent events from DB query', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('e.description') &&
+        cypher.includes('ORDER BY')
+      ) {
+        return {
+          records: [
+            {
+              description: 'Alice said hello',
+              occurred_at: '2024-01-15T10:00:00Z',
+            },
+          ],
+          metadata: [],
+        };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const result = await gather2HopNeighborhood(
+      'event-0',
+      'concept-0',
+      deps,
+      ['event-0'],
+      0,
+    );
+
+    expect(result.recentEvents).toHaveLength(1);
+    expect(result.recentEvents[0].description).toBe('Alice said hello');
+  });
+
+  it('should gracefully handle DB query failures', async () => {
+    vi.mocked(db.query).mockRejectedValue(new Error('DB connection failed'));
+
+    const result = await gather2HopNeighborhood(
+      'event-0',
+      'concept-0',
+      deps,
+      ['event-0'],
+      0,
+    );
+
+    // Should return empty results, not throw
+    expect(result.knownEntities).toHaveLength(0);
+    expect(result.recentEvents).toHaveLength(0);
+    expect(result.activeCausalChains).toHaveLength(0);
+    expect(result.similarConcepts).toHaveLength(0);
+  });
+
+  it('should run all gather queries in parallel', async () => {
+    const callOrder: string[] = [];
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (typeof cypher === 'string') {
+        if (cypher.includes('E_RELATES')) callOrder.push('entities');
+        if (cypher.includes('ORDER BY')) callOrder.push('events');
+        if (cypher.includes('X_AFFECTS')) callOrder.push('causal-entity');
+      }
+      return { records: [], metadata: [] };
+    });
+
+    await gather2HopNeighborhood('event-0', 'concept-0', deps, ['event-0'], 0);
+
+    // All queries should have been initiated (parallel via Promise.all)
+    expect(callOrder.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/core/src/ingestion/neighborhood.test.ts
+++ b/packages/core/src/ingestion/neighborhood.test.ts
@@ -60,8 +60,9 @@ describe('gather2HopNeighborhood', () => {
     const entityQuery = queryCalls.find(
       ([cypher]) => typeof cypher === 'string' && cypher.includes('X_INVOLVES'),
     );
-    expect(entityQuery).toBeDefined();
-    const passedIds = entityQuery?.[1].eventIds as string[];
+    if (!entityQuery) throw new Error('entityQuery not found');
+    const params = entityQuery[1] as Record<string, unknown>;
+    const passedIds = params.eventIds as string[];
     expect(passedIds).toHaveLength(6); // positions 2-7
     expect(passedIds[0]).toBe('event-2');
     expect(passedIds[5]).toBe('event-7');

--- a/packages/core/src/ingestion/neighborhood.test.ts
+++ b/packages/core/src/ingestion/neighborhood.test.ts
@@ -35,13 +35,7 @@ describe('gather2HopNeighborhood', () => {
   });
 
   it('should return empty neighborhood when no recent events exist', async () => {
-    const result = await gather2HopNeighborhood(
-      'event-1',
-      'concept-1',
-      deps,
-      [],
-      0,
-    );
+    const result = await gather2HopNeighborhood('concept-1', deps, [], 0);
 
     expect(result.knownEntities).toHaveLength(0);
     expect(result.recentEvents).toHaveLength(0);
@@ -52,7 +46,7 @@ describe('gather2HopNeighborhood', () => {
   it('should window to previous 5 events', async () => {
     const eventIds = Array.from({ length: 10 }, (_, i) => `event-${i}`);
 
-    await gather2HopNeighborhood('event-7', 'concept-7', deps, eventIds, 7);
+    await gather2HopNeighborhood('concept-7', deps, eventIds, 7);
 
     // Should query with event IDs from position 2 through 7 (6 events)
     const queryCalls = vi.mocked(db.query).mock.calls;
@@ -71,13 +65,7 @@ describe('gather2HopNeighborhood', () => {
   it('should handle position 0 gracefully', async () => {
     const eventIds = ['event-0'];
 
-    const result = await gather2HopNeighborhood(
-      'event-0',
-      'concept-0',
-      deps,
-      eventIds,
-      0,
-    );
+    const result = await gather2HopNeighborhood('concept-0', deps, eventIds, 0);
 
     // Should still work with just the current event
     expect(result).toBeDefined();
@@ -103,7 +91,6 @@ describe('gather2HopNeighborhood', () => {
     });
 
     const result = await gather2HopNeighborhood(
-      'event-0',
       'concept-0',
       deps,
       ['event-0'],
@@ -136,7 +123,6 @@ describe('gather2HopNeighborhood', () => {
     });
 
     const result = await gather2HopNeighborhood(
-      'event-0',
       'concept-0',
       deps,
       ['event-0'],
@@ -150,12 +136,13 @@ describe('gather2HopNeighborhood', () => {
   it('should gracefully handle DB query failures', async () => {
     vi.mocked(db.query).mockRejectedValue(new Error('DB connection failed'));
 
+    const warnings: string[] = [];
     const result = await gather2HopNeighborhood(
-      'event-0',
       'concept-0',
       deps,
       ['event-0'],
       0,
+      warnings,
     );
 
     // Should return empty results, not throw
@@ -163,6 +150,12 @@ describe('gather2HopNeighborhood', () => {
     expect(result.recentEvents).toHaveLength(0);
     expect(result.activeCausalChains).toHaveLength(0);
     expect(result.similarConcepts).toHaveLength(0);
+
+    // Should populate warnings with descriptive messages
+    expect(warnings.length).toBeGreaterThanOrEqual(3);
+    expect(warnings.some((w) => w.includes('known entities'))).toBe(true);
+    expect(warnings.some((w) => w.includes('recent events'))).toBe(true);
+    expect(warnings.some((w) => w.includes('DB connection failed'))).toBe(true);
   });
 
   it('should run all gather queries in parallel', async () => {
@@ -176,7 +169,7 @@ describe('gather2HopNeighborhood', () => {
       return { records: [], metadata: [] };
     });
 
-    await gather2HopNeighborhood('event-0', 'concept-0', deps, ['event-0'], 0);
+    await gather2HopNeighborhood('concept-0', deps, ['event-0'], 0);
 
     // All queries should have been initiated (parallel via Promise.all)
     expect(callOrder.length).toBeGreaterThanOrEqual(2);

--- a/packages/core/src/ingestion/neighborhood.ts
+++ b/packages/core/src/ingestion/neighborhood.ts
@@ -1,0 +1,194 @@
+// 2-hop neighborhood gatherer for slow path context
+import { SemanticGraph } from '../graphs/semantic.js';
+import type { IngestionDeps } from './types.js';
+
+export interface NeighborhoodContext {
+  knownEntities: { name: string; type: string; uuid: string }[];
+  recentEvents: { description: string; occurred_at: string }[];
+  activeCausalChains: {
+    cause: string;
+    effect: string;
+    confidence: number;
+  }[];
+  similarConcepts: { name: string; score: number }[];
+}
+
+const EMPTY_NEIGHBORHOOD: NeighborhoodContext = {
+  knownEntities: [],
+  recentEvents: [],
+  activeCausalChains: [],
+  similarConcepts: [],
+};
+
+/**
+ * Gather 2-hop neighborhood from a chunk's T_Event and S_Concept.
+ *
+ * Provides context for the slow path extraction prompt:
+ * - Known entities from recent events (via X_INVOLVES → E_Entity → E_RELATES)
+ * - Recent event descriptions (temporal window)
+ * - Active causal chains (via entities → X_AFFECTS → C_Node → C_CAUSES)
+ * - Similar concepts (vector similarity)
+ */
+export async function gather2HopNeighborhood(
+  _eventId: string,
+  conceptId: string,
+  deps: IngestionDeps,
+  eventIds: string[],
+  currentPosition: number,
+): Promise<NeighborhoodContext> {
+  // Window: previous 5 events (or fewer if near start)
+  const windowStart = Math.max(0, currentPosition - 5);
+  const recentEventIds = eventIds.slice(windowStart, currentPosition + 1);
+
+  if (recentEventIds.length === 0) {
+    return EMPTY_NEIGHBORHOOD;
+  }
+
+  // Run all queries in parallel
+  const [knownEntities, recentEvents, activeCausalChains, similarConcepts] =
+    await Promise.all([
+      gatherKnownEntities(deps, recentEventIds),
+      gatherRecentEvents(deps, recentEventIds),
+      gatherCausalChains(deps, recentEventIds),
+      gatherSimilarConcepts(deps, conceptId),
+    ]);
+
+  return {
+    knownEntities,
+    recentEvents,
+    activeCausalChains,
+    similarConcepts,
+  };
+}
+
+/**
+ * Known entities from recent events: T_Event → X_INVOLVES → E_Entity → E_RELATES → E_Entity
+ */
+async function gatherKnownEntities(
+  deps: IngestionDeps,
+  recentEventIds: string[],
+): Promise<NeighborhoodContext['knownEntities']> {
+  try {
+    const result = await deps.db.query(
+      `MATCH (e:T_Event)-[:X_INVOLVES]->(ent:E_Entity)
+       WHERE e.uuid IN $eventIds
+       OPTIONAL MATCH (ent)-[:E_RELATES]-(related:E_Entity)
+       WITH collect(DISTINCT ent) + collect(DISTINCT related) AS all_ents
+       UNWIND all_ents AS entity
+       WITH DISTINCT entity
+       WHERE entity IS NOT NULL
+       RETURN entity.uuid AS uuid, entity.name AS name, entity.entity_type AS type`,
+      { eventIds: recentEventIds },
+    );
+
+    return result.records.map(
+      (r: Record<string, unknown>) =>
+        ({
+          uuid: r.uuid as string,
+          name: r.name as string,
+          type: r.type as string,
+        }) as NeighborhoodContext['knownEntities'][number],
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Recent events: descriptions from the temporal window
+ */
+async function gatherRecentEvents(
+  deps: IngestionDeps,
+  recentEventIds: string[],
+): Promise<NeighborhoodContext['recentEvents']> {
+  try {
+    const result = await deps.db.query(
+      `MATCH (e:T_Event)
+       WHERE e.uuid IN $eventIds
+       RETURN e.description AS description, e.occurred_at AS occurred_at
+       ORDER BY e.occurred_at ASC`,
+      { eventIds: recentEventIds },
+    );
+
+    return result.records.map(
+      (r: Record<string, unknown>) =>
+        ({
+          description: r.description as string,
+          occurred_at: r.occurred_at as string,
+        }) as NeighborhoodContext['recentEvents'][number],
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Active causal chains from entities linked to recent events:
+ * E_Entity ← X_AFFECTS ← C_Node → C_CAUSES → C_Node
+ */
+async function gatherCausalChains(
+  deps: IngestionDeps,
+  recentEventIds: string[],
+): Promise<NeighborhoodContext['activeCausalChains']> {
+  try {
+    // First get entity IDs from recent events
+    const entityResult = await deps.db.query(
+      `MATCH (e:T_Event)-[:X_INVOLVES]->(ent:E_Entity)
+       WHERE e.uuid IN $eventIds
+       RETURN DISTINCT ent.uuid AS uuid`,
+      { eventIds: recentEventIds },
+    );
+
+    const entityIds = entityResult.records.map(
+      (r: Record<string, unknown>) => r.uuid as string,
+    );
+
+    if (entityIds.length === 0) {
+      return [];
+    }
+
+    // Then traverse causal chains from those entities
+    const result = await deps.db.query(
+      `MATCH (ent:E_Entity)<-[:X_AFFECTS]-(c:C_Node)
+       WHERE ent.uuid IN $entityIds
+       OPTIONAL MATCH (c)-[link:C_CAUSES]->(effect:C_Node)
+       RETURN c.description AS cause, effect.description AS effect, link.confidence AS confidence`,
+      { entityIds },
+    );
+
+    return result.records
+      .filter(
+        (r: Record<string, unknown>) => r.cause != null && r.effect != null,
+      )
+      .map(
+        (r: Record<string, unknown>) =>
+          ({
+            cause: r.cause as string,
+            effect: r.effect as string,
+            confidence: typeof r.confidence === 'number' ? r.confidence : 1.0,
+          }) as NeighborhoodContext['activeCausalChains'][number],
+      );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Similar concepts: vector similarity search from the current chunk's concept
+ */
+async function gatherSimilarConcepts(
+  deps: IngestionDeps,
+  conceptId: string,
+): Promise<NeighborhoodContext['similarConcepts']> {
+  try {
+    const semantic = new SemanticGraph(deps.db, deps.embeddings);
+    const matches = await semantic.getSimilar(conceptId, 5);
+
+    return matches.map((m) => ({
+      name: m.concept.name,
+      score: m.score,
+    }));
+  } catch {
+    return [];
+  }
+}

--- a/packages/core/src/ingestion/neighborhood.ts
+++ b/packages/core/src/ingestion/neighborhood.ts
@@ -30,11 +30,11 @@ const EMPTY_NEIGHBORHOOD: NeighborhoodContext = {
  * - Similar concepts (vector similarity)
  */
 export async function gather2HopNeighborhood(
-  _eventId: string,
   conceptId: string,
   deps: IngestionDeps,
   eventIds: string[],
   currentPosition: number,
+  warnings: string[] = [],
 ): Promise<NeighborhoodContext> {
   // Window: previous 5 events (or fewer if near start)
   const windowStart = Math.max(0, currentPosition - 5);
@@ -47,10 +47,10 @@ export async function gather2HopNeighborhood(
   // Run all queries in parallel
   const [knownEntities, recentEvents, activeCausalChains, similarConcepts] =
     await Promise.all([
-      gatherKnownEntities(deps, recentEventIds),
-      gatherRecentEvents(deps, recentEventIds),
-      gatherCausalChains(deps, recentEventIds),
-      gatherSimilarConcepts(deps, conceptId),
+      gatherKnownEntities(deps, recentEventIds, warnings),
+      gatherRecentEvents(deps, recentEventIds, warnings),
+      gatherCausalChains(deps, recentEventIds, warnings),
+      gatherSimilarConcepts(deps, conceptId, warnings),
     ]);
 
   return {
@@ -67,6 +67,7 @@ export async function gather2HopNeighborhood(
 async function gatherKnownEntities(
   deps: IngestionDeps,
   recentEventIds: string[],
+  warnings: string[],
 ): Promise<NeighborhoodContext['knownEntities']> {
   try {
     const result = await deps.db.query(
@@ -89,7 +90,10 @@ async function gatherKnownEntities(
           type: r.type as string,
         }) as NeighborhoodContext['knownEntities'][number],
     );
-  } catch {
+  } catch (err) {
+    warnings.push(
+      `Neighborhood: failed to gather known entities: ${errMsg(err)}`,
+    );
     return [];
   }
 }
@@ -100,6 +104,7 @@ async function gatherKnownEntities(
 async function gatherRecentEvents(
   deps: IngestionDeps,
   recentEventIds: string[],
+  warnings: string[],
 ): Promise<NeighborhoodContext['recentEvents']> {
   try {
     const result = await deps.db.query(
@@ -117,7 +122,10 @@ async function gatherRecentEvents(
           occurred_at: r.occurred_at as string,
         }) as NeighborhoodContext['recentEvents'][number],
     );
-  } catch {
+  } catch (err) {
+    warnings.push(
+      `Neighborhood: failed to gather recent events: ${errMsg(err)}`,
+    );
     return [];
   }
 }
@@ -129,6 +137,7 @@ async function gatherRecentEvents(
 async function gatherCausalChains(
   deps: IngestionDeps,
   recentEventIds: string[],
+  warnings: string[],
 ): Promise<NeighborhoodContext['activeCausalChains']> {
   try {
     // First get entity IDs from recent events
@@ -168,7 +177,10 @@ async function gatherCausalChains(
             confidence: typeof r.confidence === 'number' ? r.confidence : 1.0,
           }) as NeighborhoodContext['activeCausalChains'][number],
       );
-  } catch {
+  } catch (err) {
+    warnings.push(
+      `Neighborhood: failed to gather causal chains: ${errMsg(err)}`,
+    );
     return [];
   }
 }
@@ -179,6 +191,7 @@ async function gatherCausalChains(
 async function gatherSimilarConcepts(
   deps: IngestionDeps,
   conceptId: string,
+  warnings: string[],
 ): Promise<NeighborhoodContext['similarConcepts']> {
   try {
     const semantic = new SemanticGraph(deps.db, deps.embeddings);
@@ -188,7 +201,14 @@ async function gatherSimilarConcepts(
       name: m.concept.name,
       score: m.score,
     }));
-  } catch {
+  } catch (err) {
+    warnings.push(
+      `Neighborhood: failed to gather similar concepts for ${conceptId}: ${errMsg(err)}`,
+    );
     return [];
   }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/packages/core/src/ingestion/slow-path.test.ts
+++ b/packages/core/src/ingestion/slow-path.test.ts
@@ -1,0 +1,375 @@
+import type { EmbeddingProvider, LLMProvider } from '@polyg-mcp/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FalkorDBAdapter } from '../storage/falkordb.js';
+import { CONVERSATION_PROFILE } from './profiles.js';
+import { runSlowPath } from './slow-path.js';
+import type {
+  ChunkExtraction,
+  FastPathResult,
+  IngestionDeps,
+  ParsedChunk,
+} from './types.js';
+
+/**
+ * Create a mock DB that tracks created nodes so entity lookups work.
+ * EntityGraph.linkEntities calls getEntity(uuid) internally, which needs
+ * to find the entity node created by addEntity.
+ */
+function createMockDb(): FalkorDBAdapter {
+  let nodeCounter = 0;
+  const createdNodes = new Map<
+    string,
+    { uuid: string; label: string; props: Record<string, unknown> }
+  >();
+
+  const mockQuery = vi
+    .fn()
+    .mockImplementation(
+      async (cypher: string, params: Record<string, unknown>) => {
+        // Entity lookup by UUID (used by getEntity → linkEntities)
+        if (
+          typeof cypher === 'string' &&
+          cypher.includes('E_Entity') &&
+          cypher.includes('{uuid: $id}')
+        ) {
+          const id = params.id as string;
+          const node = createdNodes.get(id);
+          if (node) {
+            return {
+              records: [
+                {
+                  n: {
+                    properties: {
+                      uuid: node.uuid,
+                      ...node.props,
+                    },
+                  },
+                },
+              ],
+              metadata: [],
+            };
+          }
+        }
+        // Entity dedup check by name+type (used by addEntity)
+        if (
+          typeof cypher === 'string' &&
+          cypher.includes('E_Entity') &&
+          cypher.includes('{name: $name')
+        ) {
+          const name = params.name as string;
+          const type = params.entityType as string;
+          for (const node of createdNodes.values()) {
+            if (
+              node.label === 'E_Entity' &&
+              node.props.name === name &&
+              node.props.entity_type === type
+            ) {
+              return {
+                records: [
+                  {
+                    n: {
+                      properties: {
+                        uuid: node.uuid,
+                        ...node.props,
+                      },
+                    },
+                  },
+                ],
+                metadata: [],
+              };
+            }
+          }
+        }
+        // Causal node lookup by description (used by findOrCreate)
+        if (
+          typeof cypher === 'string' &&
+          cypher.includes('C_Node') &&
+          cypher.includes('toLower')
+        ) {
+          const desc = params.desc as string;
+          for (const node of createdNodes.values()) {
+            if (
+              node.label === 'C_Node' &&
+              (node.props.description as string).toLowerCase() ===
+                desc.toLowerCase()
+            ) {
+              return {
+                records: [
+                  {
+                    n: {
+                      properties: {
+                        uuid: node.uuid,
+                        ...node.props,
+                      },
+                    },
+                  },
+                ],
+                metadata: [],
+              };
+            }
+          }
+        }
+        return { records: [], metadata: [] };
+      },
+    );
+
+  return {
+    query: mockQuery,
+    createNode: vi
+      .fn()
+      .mockImplementation((label: string, props: Record<string, unknown>) => {
+        nodeCounter++;
+        const uuid = `uuid-${nodeCounter}`;
+        createdNodes.set(uuid, { uuid, label, props });
+        return Promise.resolve(uuid);
+      }),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  } as unknown as FalkorDBAdapter;
+}
+
+function createMockEmbeddings(): EmbeddingProvider {
+  return {
+    embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+    embedBatch: vi.fn().mockResolvedValue([[0.1, 0.2]]),
+  };
+}
+
+const validExtraction: ChunkExtraction = {
+  entities: [
+    { name: 'Alice', entity_type: 'person' },
+    { name: 'Acme Corp', entity_type: 'organization' },
+  ],
+  relationships: [
+    { source: 'Alice', target: 'Acme Corp', relationship_type: 'works_at' },
+  ],
+  causal_links: [
+    {
+      cause: 'Alice joined Acme',
+      effect: 'Team expanded',
+      confidence: 0.9,
+      entities: ['Alice'],
+    },
+  ],
+  facts: [
+    {
+      subject: 'Alice',
+      predicate: 'employer',
+      object: 'Acme Corp',
+      valid_from: '2024-01-01T00:00:00Z',
+      subject_entity: 'Alice',
+    },
+  ],
+};
+
+function makeChunks(count: number): ParsedChunk[] {
+  return Array.from({ length: count }, (_, i) => ({
+    chunk_id: `chunk_${i.toString().padStart(3, '0')}`,
+    content: `Message ${i}`,
+    position: i,
+    metadata: {
+      source_format: 'conversation' as const,
+      speaker: 'Alice',
+      turn_index: i,
+    },
+  }));
+}
+
+function makeFastResult(count: number): FastPathResult {
+  return {
+    eventIds: Array.from({ length: count }, (_, i) => `event-${i}`),
+    conceptIds: Array.from({ length: count }, (_, i) => `concept-${i}`),
+    embeddingTimeMs: 10,
+    writeTimeMs: 20,
+  };
+}
+
+describe('runSlowPath', () => {
+  let db: FalkorDBAdapter;
+  let llm: LLMProvider;
+  let deps: IngestionDeps;
+
+  beforeEach(() => {
+    db = createMockDb();
+    llm = {
+      complete: vi.fn().mockResolvedValue(JSON.stringify(validExtraction)),
+    };
+    deps = {
+      db,
+      llm,
+      embeddings: createMockEmbeddings(),
+    } as unknown as IngestionDeps;
+    vi.clearAllMocks();
+  });
+
+  it('should extract and write graph data for each chunk', async () => {
+    const chunks = makeChunks(2);
+    const fastResult = makeFastResult(2);
+
+    const result = await runSlowPath(
+      chunks,
+      fastResult,
+      CONVERSATION_PROFILE,
+      deps,
+    );
+
+    expect(result.extractedChunks).toBe(2);
+    expect(result.skippedChunks).toBe(0);
+    expect(result.entities_created).toBeGreaterThan(0);
+    expect(result.relationships_created).toBeGreaterThan(0);
+    expect(result.facts_created).toBeGreaterThan(0);
+    expect(result.causal_links_created).toBeGreaterThan(0);
+  });
+
+  it('should call LLM once per chunk', async () => {
+    const chunks = makeChunks(3);
+    const fastResult = makeFastResult(3);
+
+    await runSlowPath(chunks, fastResult, CONVERSATION_PROFILE, deps);
+
+    expect(llm.complete).toHaveBeenCalledTimes(3);
+  });
+
+  it('should retry once on LLM failure then skip', async () => {
+    vi.mocked(llm.complete).mockRejectedValue(new Error('LLM error'));
+
+    const chunks = makeChunks(1);
+    const fastResult = makeFastResult(1);
+
+    const result = await runSlowPath(
+      chunks,
+      fastResult,
+      CONVERSATION_PROFILE,
+      deps,
+    );
+
+    // 2 attempts per chunk
+    expect(llm.complete).toHaveBeenCalledTimes(2);
+    expect(result.skippedChunks).toBe(1);
+    expect(result.skippedChunkIds).toEqual(['chunk_000']);
+    expect(result.extractedChunks).toBe(0);
+  });
+
+  it('should succeed on retry after first failure', async () => {
+    vi.mocked(llm.complete)
+      .mockRejectedValueOnce(new Error('Transient error'))
+      .mockResolvedValueOnce(JSON.stringify(validExtraction));
+
+    const chunks = makeChunks(1);
+    const fastResult = makeFastResult(1);
+
+    const result = await runSlowPath(
+      chunks,
+      fastResult,
+      CONVERSATION_PROFILE,
+      deps,
+    );
+
+    expect(llm.complete).toHaveBeenCalledTimes(2);
+    expect(result.extractedChunks).toBe(1);
+    expect(result.skippedChunks).toBe(0);
+  });
+
+  it('should skip chunks with invalid LLM JSON', async () => {
+    vi.mocked(llm.complete).mockResolvedValue('not valid json');
+
+    const chunks = makeChunks(1);
+    const fastResult = makeFastResult(1);
+
+    const result = await runSlowPath(
+      chunks,
+      fastResult,
+      CONVERSATION_PROFILE,
+      deps,
+    );
+
+    expect(result.skippedChunks).toBe(1);
+    expect(result.extractedChunks).toBe(0);
+  });
+
+  it('should accumulate entity map across chunks', async () => {
+    // First chunk creates Alice, second chunk references Alice again
+    const extraction1: ChunkExtraction = {
+      entities: [{ name: 'Alice', entity_type: 'person' }],
+      relationships: [],
+      causal_links: [],
+      facts: [],
+    };
+    const extraction2: ChunkExtraction = {
+      entities: [{ name: 'Alice', entity_type: 'person' }],
+      relationships: [
+        {
+          source: 'Alice',
+          target: 'Alice',
+          relationship_type: 'self_ref',
+        },
+      ],
+      causal_links: [],
+      facts: [],
+    };
+
+    vi.mocked(llm.complete)
+      .mockResolvedValueOnce(JSON.stringify(extraction1))
+      .mockResolvedValueOnce(JSON.stringify(extraction2));
+
+    const chunks = makeChunks(2);
+    const fastResult = makeFastResult(2);
+
+    const result = await runSlowPath(
+      chunks,
+      fastResult,
+      CONVERSATION_PROFILE,
+      deps,
+    );
+
+    expect(result.extractedChunks).toBe(2);
+    // Alice should only be counted as created once
+    expect(result.entities_created).toBe(1);
+  });
+
+  it('should handle empty chunks list', async () => {
+    const result = await runSlowPath(
+      [],
+      makeFastResult(0),
+      CONVERSATION_PROFILE,
+      deps,
+    );
+
+    expect(result.extractedChunks).toBe(0);
+    expect(result.skippedChunks).toBe(0);
+    expect(llm.complete).not.toHaveBeenCalled();
+  });
+
+  it('should create cross-links from events to extracted entities', async () => {
+    const extraction: ChunkExtraction = {
+      entities: [{ name: 'Bob', entity_type: 'person' }],
+      relationships: [],
+      causal_links: [],
+      facts: [],
+    };
+    vi.mocked(llm.complete).mockResolvedValue(JSON.stringify(extraction));
+
+    const chunks = makeChunks(1);
+    const fastResult = makeFastResult(1);
+
+    const result = await runSlowPath(
+      chunks,
+      fastResult,
+      CONVERSATION_PROFILE,
+      deps,
+    );
+
+    expect(result.cross_links_created).toBeGreaterThan(0);
+  });
+
+  it('should pass responseFormat json to LLM', async () => {
+    const chunks = makeChunks(1);
+    const fastResult = makeFastResult(1);
+
+    await runSlowPath(chunks, fastResult, CONVERSATION_PROFILE, deps);
+
+    expect(llm.complete).toHaveBeenCalledWith(
+      expect.objectContaining({ responseFormat: 'json' }),
+    );
+  });
+});

--- a/packages/core/src/ingestion/slow-path.test.ts
+++ b/packages/core/src/ingestion/slow-path.test.ts
@@ -219,6 +219,7 @@ describe('runSlowPath', () => {
     expect(result.relationships_created).toBeGreaterThan(0);
     expect(result.facts_created).toBeGreaterThan(0);
     expect(result.causal_links_created).toBeGreaterThan(0);
+    expect(result.warnings).toEqual([]);
   });
 
   it('should call LLM once per chunk', async () => {
@@ -360,6 +361,58 @@ describe('runSlowPath', () => {
     );
 
     expect(result.cross_links_created).toBeGreaterThan(0);
+  });
+
+  it('should populate warnings when extraction fails', async () => {
+    vi.mocked(llm.complete).mockRejectedValue(new Error('LLM timeout'));
+
+    const chunks = makeChunks(1);
+    const fastResult = makeFastResult(1);
+
+    const result = await runSlowPath(
+      chunks,
+      fastResult,
+      CONVERSATION_PROFILE,
+      deps,
+    );
+
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('chunk_000');
+    expect(result.warnings[0]).toContain('LLM timeout');
+  });
+
+  it('should populate warnings on entity write failures', async () => {
+    // First LLM call succeeds with extraction containing an entity
+    const extraction: ChunkExtraction = {
+      entities: [{ name: 'FailEnt', entity_type: 'person' }],
+      relationships: [],
+      causal_links: [],
+      facts: [],
+    };
+    vi.mocked(llm.complete).mockResolvedValue(JSON.stringify(extraction));
+
+    // Make createNode fail for entity creation
+    const origCreateNode = vi.mocked(db.createNode);
+    origCreateNode.mockImplementation(
+      async (label: string, _props: Record<string, unknown>) => {
+        if (label === 'E_Entity') throw new Error('DB write failed');
+        return 'uuid-ok';
+      },
+    );
+
+    const chunks = makeChunks(1);
+    const fastResult = makeFastResult(1);
+
+    const result = await runSlowPath(
+      chunks,
+      fastResult,
+      CONVERSATION_PROFILE,
+      deps,
+    );
+
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain('FailEnt');
+    expect(result.warnings[0]).toContain('Failed to create entity');
   });
 
   it('should pass responseFormat json to LLM', async () => {

--- a/packages/core/src/ingestion/slow-path.ts
+++ b/packages/core/src/ingestion/slow-path.ts
@@ -1,0 +1,287 @@
+// Slow path — per-chunk LLM extraction + graph writes
+import type { Entity } from '@polyg-mcp/shared';
+import { CausalGraph } from '../graphs/causal.js';
+import { EntityGraph } from '../graphs/entity.js';
+import { TemporalGraph } from '../graphs/temporal.js';
+import { buildExtractionPrompt } from './extraction-prompt.js';
+import { gather2HopNeighborhood } from './neighborhood.js';
+import type {
+  ChunkExtraction,
+  DocumentProfile,
+  FastPathResult,
+  IngestionDeps,
+  ParsedChunk,
+} from './types.js';
+import { ChunkExtractionSchema } from './types.js';
+
+export interface SlowPathResult {
+  extractedChunks: number;
+  skippedChunks: number;
+  skippedChunkIds: string[];
+  entities_created: number;
+  relationships_created: number;
+  facts_created: number;
+  causal_nodes_created: number;
+  causal_links_created: number;
+  cross_links_created: number;
+}
+
+export async function runSlowPath(
+  chunks: ParsedChunk[],
+  fastPathResult: FastPathResult,
+  profile: DocumentProfile,
+  deps: IngestionDeps,
+  _concurrency = 1,
+): Promise<SlowPathResult> {
+  const entityGraph = new EntityGraph(deps.db);
+  const temporalGraph = new TemporalGraph(deps.db);
+  const causalGraph = new CausalGraph(deps.db);
+
+  const result: SlowPathResult = {
+    extractedChunks: 0,
+    skippedChunks: 0,
+    skippedChunkIds: [],
+    entities_created: 0,
+    relationships_created: 0,
+    facts_created: 0,
+    causal_nodes_created: 0,
+    causal_links_created: 0,
+    cross_links_created: 0,
+  };
+
+  // Global entity map across all chunks: normalized name → Entity
+  const globalEntityMap = new Map<string, Entity>();
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    const eventId = fastPathResult.eventIds[i];
+    const conceptId = fastPathResult.conceptIds[i];
+
+    // 1. Gather neighborhood context
+    const neighborhood = await gather2HopNeighborhood(
+      eventId,
+      conceptId,
+      deps,
+      fastPathResult.eventIds,
+      i,
+    );
+
+    // 2. LLM extraction with retry
+    const extraction = await extractWithRetry(
+      chunk,
+      profile,
+      neighborhood,
+      deps,
+    );
+    if (!extraction) {
+      result.skippedChunks++;
+      result.skippedChunkIds.push(chunk.chunk_id);
+      continue;
+    }
+
+    // 3. Write extraction to graph
+    const writeResult = await writeChunkExtraction(
+      extraction,
+      eventId,
+      entityGraph,
+      temporalGraph,
+      causalGraph,
+      globalEntityMap,
+    );
+
+    result.extractedChunks++;
+    result.entities_created += writeResult.entities_created;
+    result.relationships_created += writeResult.relationships_created;
+    result.facts_created += writeResult.facts_created;
+    result.causal_nodes_created += writeResult.causal_nodes_created;
+    result.causal_links_created += writeResult.causal_links_created;
+    result.cross_links_created += writeResult.cross_links_created;
+  }
+
+  return result;
+}
+
+/**
+ * Attempt LLM extraction with one retry on failure.
+ */
+async function extractWithRetry(
+  chunk: ParsedChunk,
+  profile: DocumentProfile,
+  neighborhood: ReturnType<typeof gather2HopNeighborhood> extends Promise<
+    infer T
+  >
+    ? T
+    : never,
+  deps: IngestionDeps,
+): Promise<ChunkExtraction | null> {
+  const { system, user } = buildExtractionPrompt(chunk, profile, neighborhood);
+  const prompt = `${system}\n\n${user}`;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const raw = await deps.llm.complete({
+        prompt,
+        responseFormat: 'json',
+      });
+      return ChunkExtractionSchema.parse(JSON.parse(raw));
+    } catch {
+      if (attempt === 1) {
+        return null; // both attempts failed
+      }
+      // retry
+    }
+  }
+
+  return null;
+}
+
+interface WriteResult {
+  entities_created: number;
+  relationships_created: number;
+  facts_created: number;
+  causal_nodes_created: number;
+  causal_links_created: number;
+  cross_links_created: number;
+}
+
+/**
+ * Write a chunk's extraction to the graph.
+ * Follows the pattern from benchmarks/src/locomo/ingest.ts → writeToGraphs().
+ */
+async function writeChunkExtraction(
+  extraction: ChunkExtraction,
+  eventId: string,
+  entityGraph: EntityGraph,
+  temporalGraph: TemporalGraph,
+  causalGraph: CausalGraph,
+  globalEntityMap: Map<string, Entity>,
+): Promise<WriteResult> {
+  const result: WriteResult = {
+    entities_created: 0,
+    relationships_created: 0,
+    facts_created: 0,
+    causal_nodes_created: 0,
+    causal_links_created: 0,
+    cross_links_created: 0,
+  };
+
+  // 1. Entities — addEntity auto-deduplicates by name+type
+  for (const ent of extraction.entities) {
+    try {
+      const entity = await entityGraph.addEntity(
+        ent.name,
+        ent.entity_type,
+        ent.properties,
+      );
+      const key = normalizeEntityKey(ent.name);
+      if (!globalEntityMap.has(key)) {
+        result.entities_created++;
+      }
+      globalEntityMap.set(key, entity);
+    } catch {
+      // Skip individual entity failures
+    }
+  }
+
+  // 2. Relationships — resolve names via globalEntityMap
+  for (const rel of extraction.relationships) {
+    try {
+      const source = globalEntityMap.get(normalizeEntityKey(rel.source));
+      const target = globalEntityMap.get(normalizeEntityKey(rel.target));
+      if (source && target) {
+        await entityGraph.linkEntities(
+          source.uuid,
+          target.uuid,
+          rel.relationship_type,
+        );
+        result.relationships_created++;
+      }
+    } catch {
+      // Skip individual relationship failures
+    }
+  }
+
+  // 3. Facts — create fact + link to subject entity
+  for (const fact of extraction.facts) {
+    try {
+      const factNode = await temporalGraph.addFact(
+        fact.subject,
+        fact.predicate,
+        fact.object,
+        new Date(fact.valid_from),
+        fact.valid_to ? new Date(fact.valid_to) : undefined,
+      );
+      result.facts_created++;
+
+      // Link fact to subject entity if available
+      if (fact.subject_entity) {
+        const subjectEntity = globalEntityMap.get(
+          normalizeEntityKey(fact.subject_entity),
+        );
+        if (subjectEntity) {
+          await temporalGraph.linkFactToEntity(
+            factNode.uuid,
+            subjectEntity.uuid,
+          );
+          result.cross_links_created++;
+        }
+      }
+    } catch {
+      // Skip individual fact failures
+    }
+  }
+
+  // 4. Causal links — findOrCreate nodes + addLink + link to entities + link to event
+  for (const causal of extraction.causal_links) {
+    try {
+      const causeNode = await causalGraph.findOrCreate(causal.cause);
+      const effectNode = await causalGraph.findOrCreate(causal.effect);
+      result.causal_nodes_created += 2; // approximate: findOrCreate may reuse
+
+      await causalGraph.addLink(
+        causeNode.uuid,
+        effectNode.uuid,
+        causal.confidence,
+        causal.evidence,
+      );
+      result.causal_links_created++;
+
+      // Link causal nodes to this chunk's event
+      await causalGraph.linkToEvent(causeNode.uuid, eventId);
+      result.cross_links_created++;
+
+      // Link causal nodes to involved entities
+      if (causal.entities) {
+        for (const entName of causal.entities) {
+          const entity = globalEntityMap.get(normalizeEntityKey(entName));
+          if (entity) {
+            await causalGraph.linkToEntity(causeNode.uuid, entity.uuid);
+            await causalGraph.linkToEntity(effectNode.uuid, entity.uuid);
+            result.cross_links_created += 2;
+          }
+        }
+      }
+    } catch {
+      // Skip individual causal link failures
+    }
+  }
+
+  // 5. Cross-link: this chunk's T_Event → X_INVOLVES → extracted entities
+  for (const ent of extraction.entities) {
+    try {
+      const entity = globalEntityMap.get(normalizeEntityKey(ent.name));
+      if (entity) {
+        await temporalGraph.linkEventToEntity(eventId, entity.uuid);
+        result.cross_links_created++;
+      }
+    } catch {
+      // Skip individual cross-link failures
+    }
+  }
+
+  return result;
+}
+
+function normalizeEntityKey(name: string): string {
+  return name.toLowerCase().trim();
+}

--- a/packages/core/src/ingestion/slow-path.ts
+++ b/packages/core/src/ingestion/slow-path.ts
@@ -4,6 +4,7 @@ import { CausalGraph } from '../graphs/causal.js';
 import { EntityGraph } from '../graphs/entity.js';
 import { TemporalGraph } from '../graphs/temporal.js';
 import { buildExtractionPrompt } from './extraction-prompt.js';
+import type { NeighborhoodContext } from './neighborhood.js';
 import { gather2HopNeighborhood } from './neighborhood.js';
 import type {
   ChunkExtraction,
@@ -24,6 +25,7 @@ export interface SlowPathResult {
   causal_nodes_created: number;
   causal_links_created: number;
   cross_links_created: number;
+  warnings: string[];
 }
 
 export async function runSlowPath(
@@ -47,6 +49,7 @@ export async function runSlowPath(
     causal_nodes_created: 0,
     causal_links_created: 0,
     cross_links_created: 0,
+    warnings: [],
   };
 
   // Global entity map across all chunks: normalized name → Entity
@@ -59,11 +62,11 @@ export async function runSlowPath(
 
     // 1. Gather neighborhood context
     const neighborhood = await gather2HopNeighborhood(
-      eventId,
       conceptId,
       deps,
       fastPathResult.eventIds,
       i,
+      result.warnings,
     );
 
     // 2. LLM extraction with retry
@@ -72,6 +75,7 @@ export async function runSlowPath(
       profile,
       neighborhood,
       deps,
+      result.warnings,
     );
     if (!extraction) {
       result.skippedChunks++;
@@ -87,6 +91,7 @@ export async function runSlowPath(
       temporalGraph,
       causalGraph,
       globalEntityMap,
+      result.warnings,
     );
 
     result.extractedChunks++;
@@ -107,12 +112,9 @@ export async function runSlowPath(
 async function extractWithRetry(
   chunk: ParsedChunk,
   profile: DocumentProfile,
-  neighborhood: ReturnType<typeof gather2HopNeighborhood> extends Promise<
-    infer T
-  >
-    ? T
-    : never,
+  neighborhood: NeighborhoodContext,
   deps: IngestionDeps,
+  warnings: string[],
 ): Promise<ChunkExtraction | null> {
   const { system, user } = buildExtractionPrompt(chunk, profile, neighborhood);
   const prompt = `${system}\n\n${user}`;
@@ -124,9 +126,12 @@ async function extractWithRetry(
         responseFormat: 'json',
       });
       return ChunkExtractionSchema.parse(JSON.parse(raw));
-    } catch {
+    } catch (err) {
       if (attempt === 1) {
-        return null; // both attempts failed
+        warnings.push(
+          `Extraction failed for chunk ${chunk.chunk_id} after 2 attempts: ${errMsg(err)}`,
+        );
+        return null;
       }
       // retry
     }
@@ -155,6 +160,7 @@ async function writeChunkExtraction(
   temporalGraph: TemporalGraph,
   causalGraph: CausalGraph,
   globalEntityMap: Map<string, Entity>,
+  warnings: string[],
 ): Promise<WriteResult> {
   const result: WriteResult = {
     entities_created: 0,
@@ -178,8 +184,10 @@ async function writeChunkExtraction(
         result.entities_created++;
       }
       globalEntityMap.set(key, entity);
-    } catch {
-      // Skip individual entity failures
+    } catch (err) {
+      warnings.push(
+        `Failed to create entity "${ent.name}" (${ent.entity_type}): ${errMsg(err)}`,
+      );
     }
   }
 
@@ -196,8 +204,10 @@ async function writeChunkExtraction(
         );
         result.relationships_created++;
       }
-    } catch {
-      // Skip individual relationship failures
+    } catch (err) {
+      warnings.push(
+        `Failed to link "${rel.source}" → "${rel.target}" (${rel.relationship_type}): ${errMsg(err)}`,
+      );
     }
   }
 
@@ -226,8 +236,10 @@ async function writeChunkExtraction(
           result.cross_links_created++;
         }
       }
-    } catch {
-      // Skip individual fact failures
+    } catch (err) {
+      warnings.push(
+        `Failed to create fact "${fact.subject} ${fact.predicate} ${fact.object}": ${errMsg(err)}`,
+      );
     }
   }
 
@@ -261,8 +273,10 @@ async function writeChunkExtraction(
           }
         }
       }
-    } catch {
-      // Skip individual causal link failures
+    } catch (err) {
+      warnings.push(
+        `Failed to create causal link "${causal.cause}" → "${causal.effect}": ${errMsg(err)}`,
+      );
     }
   }
 
@@ -274,8 +288,10 @@ async function writeChunkExtraction(
         await temporalGraph.linkEventToEntity(eventId, entity.uuid);
         result.cross_links_created++;
       }
-    } catch {
-      // Skip individual cross-link failures
+    } catch (err) {
+      warnings.push(
+        `Failed to cross-link event ${eventId} to entity "${ent.name}": ${errMsg(err)}`,
+      );
     }
   }
 
@@ -284,4 +300,8 @@ async function writeChunkExtraction(
 
 function normalizeEntityKey(name: string): string {
   return name.toLowerCase().trim();
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }


### PR DESCRIPTION
## Summary
- **Fast path** (`fast-path.ts`): Batch embeds all chunks in a single API call, then sequentially writes T_Event + S_Concept nodes with FOLLOWS temporal backbone
- **Neighborhood gatherer** (`neighborhood.ts`): Parallel 2-hop queries for known entities (X_INVOLVES → E_Entity → E_RELATES), recent events, active causal chains (X_AFFECTS → C_Node → C_CAUSES), and similar concepts (vector search)
- **Extraction prompt** (`extraction-prompt.ts`): Profile-parameterized LLM prompt with entity reuse directives and neighborhood context injection
- **Slow path** (`slow-path.ts`): Per-chunk LLM extraction with retry logic, Zod validation, graph writes (entities, relationships, facts, causal links, cross-links), and global entity map accumulation across chunks

**PR B** of the [ingestion implementation plan](docs/ingestion_implementation.md) — Steps 1.4, 1.5, 1.6, 1.7. Depends on PR #101 (foundation).

## New files
| File | Purpose |
|------|---------|
| `ingestion/fast-path.ts` | Batch embed + sequential graph write |
| `ingestion/neighborhood.ts` | 2-hop context gatherer |
| `ingestion/extraction-prompt.ts` | Per-chunk LLM prompt builder |
| `ingestion/slow-path.ts` | LLM extraction + graph writes |

## Test plan
- [x] 39 new unit tests: fast path (7), neighborhood (7), extraction prompt (16), slow path (9)
- [x] Smart mock DB in slow path tracks created nodes for entity lookup chain
- [x] All 929 existing + new tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)