### PR TITLE
feat: ingestion post-process + orchestrator

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,15 @@ export * from './agents/index.js';
 export * from './embeddings/index.js';
 export * from './executor/index.js';
 export * from './graphs/index.js';
+export { ingest } from './ingestion/index.js';
+export type {
+  DeduplicationResult,
+  DocumentProfile,
+  IngestInput,
+  IngestionDeps,
+  IngestionReport,
+  InputFormat,
+} from './ingestion/types.js';
 export * from './llm/index.js';
 export { Orchestrator, type OrchestratorConfig } from './orchestrator.js';
 export * from './retrieval/index.js';

--- a/packages/core/src/ingestion/index.ts
+++ b/packages/core/src/ingestion/index.ts
@@ -1,0 +1,204 @@
+// Ingestion pipeline — public API
+import { runFastPath } from './fast-path.js';
+import { parse } from './parser/index.js';
+import {
+  checkQuality,
+  getQualityMetrics,
+  runPostProcess,
+} from './post-process.js';
+import { getDefaultProfile } from './profiles.js';
+import { runSlowPath } from './slow-path.js';
+import type {
+  DeduplicationResult,
+  IngestInput,
+  IngestionDeps,
+  IngestionReport,
+} from './types.js';
+
+/**
+ * Ingest a document into the multi-graph memory.
+ *
+ * Pipeline: parse → profile → fast path → slow path → post-process → quality checks.
+ */
+export async function ingest(
+  input: IngestInput,
+  deps: IngestionDeps,
+): Promise<IngestionReport> {
+  const totalStart = Date.now();
+
+  // --- Edge case: empty content ---
+  if (!input.content || input.content.trim().length === 0) {
+    return failedReport('Empty content provided');
+  }
+
+  // --- Step 1: Parse ---
+  const parseStart = Date.now();
+  let chunks: ReturnType<typeof parse>;
+  try {
+    chunks = parse(input.content, input.format);
+  } catch (err) {
+    return failedReport(`Parse failed: ${errMsg(err)}`);
+  }
+  const parseMs = Date.now() - parseStart;
+
+  if (chunks.length === 0) {
+    return failedReport('No chunks produced after parsing');
+  }
+
+  // --- Step 2: Profile ---
+  const profileStart = Date.now();
+  const profile =
+    input.profileOverride ??
+    getDefaultProfile(chunks[0].metadata.source_format);
+  const profileMs = Date.now() - profileStart;
+
+  // --- Step 3: Fast path ---
+  const fastStart = Date.now();
+  const fastResult = await runFastPath(chunks, deps);
+  const fastMs = Date.now() - fastStart;
+
+  // --- Step 4: Slow path ---
+  const slowStart = Date.now();
+  const slowResult = await runSlowPath(
+    chunks,
+    fastResult,
+    profile,
+    deps,
+    input.concurrency,
+  );
+  const slowMs = Date.now() - slowStart;
+
+  // --- Step 5: Post-process (non-fatal) ---
+  let deduplication: DeduplicationResult = {
+    mergedEntities: 0,
+    mergedCausalNodes: 0,
+    factsWithUpdatedValidity: 0,
+    orphanedLinksRemoved: 0,
+  };
+  const postProcessWarnings: string[] = [];
+  const postStart = Date.now();
+  try {
+    deduplication = await runPostProcess(deps);
+  } catch (err) {
+    postProcessWarnings.push(`Post-processing failed: ${errMsg(err)}`);
+  }
+  const postMs = Date.now() - postStart;
+
+  // --- Step 6: Quality checks (non-fatal) ---
+  let qualityWarnings: string[] = [];
+  try {
+    const metrics = await getQualityMetrics(deps);
+    qualityWarnings = checkQuality(
+      metrics.entityCount,
+      chunks.length,
+      slowResult.skippedChunks,
+      metrics.disconnectedRatio,
+      metrics.maxCausalDepth,
+    );
+  } catch (err) {
+    qualityWarnings.push(`Quality check failed: ${errMsg(err)}`);
+  }
+
+  // --- Step 7: Compile report ---
+  const allWarnings = [
+    ...slowResult.warnings,
+    ...postProcessWarnings,
+    ...qualityWarnings,
+  ];
+  const totalMs = Date.now() - totalStart;
+
+  return {
+    status: allWarnings.length > 0 ? 'completed_with_warnings' : 'completed',
+    chunks: {
+      total: chunks.length,
+      parsed: chunks.length,
+      fast_path_written: fastResult.eventIds.length,
+      slow_path_extracted: slowResult.extractedChunks,
+      slow_path_skipped: slowResult.skippedChunks,
+    },
+    graph: {
+      entities_created: slowResult.entities_created,
+      events_created: fastResult.eventIds.length,
+      facts_created: slowResult.facts_created,
+      concepts_created: fastResult.conceptIds.length,
+      causal_nodes_created: slowResult.causal_nodes_created,
+      causal_links_created: slowResult.causal_links_created,
+      cross_links_created: slowResult.cross_links_created,
+      relationships_created: slowResult.relationships_created,
+    },
+    deduplication,
+    quality_warnings: allWarnings,
+    cost: {
+      profiler_calls: 0, // Phase 1: no LLM profiler
+      extraction_calls: slowResult.extractedChunks,
+      embedding_calls: 1,
+      total_llm_calls: slowResult.extractedChunks,
+    },
+    timing: {
+      parse_ms: parseMs,
+      profile_ms: profileMs,
+      fast_path_ms: fastMs,
+      slow_path_ms: slowMs,
+      post_process_ms: postMs,
+      total_ms: totalMs,
+    },
+  };
+}
+
+function failedReport(reason: string): IngestionReport {
+  return {
+    status: 'failed',
+    chunks: {
+      total: 0,
+      parsed: 0,
+      fast_path_written: 0,
+      slow_path_extracted: 0,
+      slow_path_skipped: 0,
+    },
+    graph: {
+      entities_created: 0,
+      events_created: 0,
+      facts_created: 0,
+      concepts_created: 0,
+      causal_nodes_created: 0,
+      causal_links_created: 0,
+      cross_links_created: 0,
+      relationships_created: 0,
+    },
+    deduplication: {
+      mergedEntities: 0,
+      mergedCausalNodes: 0,
+      factsWithUpdatedValidity: 0,
+      orphanedLinksRemoved: 0,
+    },
+    quality_warnings: [reason],
+    cost: {
+      profiler_calls: 0,
+      extraction_calls: 0,
+      embedding_calls: 0,
+      total_llm_calls: 0,
+    },
+    timing: {
+      parse_ms: 0,
+      profile_ms: 0,
+      fast_path_ms: 0,
+      slow_path_ms: 0,
+      post_process_ms: 0,
+      total_ms: 0,
+    },
+  };
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// Re-export public types
+export type {
+  DeduplicationResult,
+  DocumentProfile,
+  IngestInput,
+  IngestionDeps,
+  IngestionReport,
+  InputFormat,
+} from './types.js';

--- a/packages/core/src/ingestion/index.ts
+++ b/packages/core/src/ingestion/index.ts
@@ -132,8 +132,7 @@ export async function ingest(
       profiler_calls: 0, // Phase 1: no LLM profiler
       extraction_calls: slowResult.extractedChunks + slowResult.skippedChunks,
       embedding_calls: 1,
-      total_llm_calls:
-        slowResult.extractedChunks + slowResult.skippedChunks,
+      total_llm_calls: slowResult.extractedChunks + slowResult.skippedChunks,
     },
     timing: {
       parse_ms: parseMs,

--- a/packages/core/src/ingestion/index.ts
+++ b/packages/core/src/ingestion/index.ts
@@ -130,9 +130,10 @@ export async function ingest(
     quality_warnings: allWarnings,
     cost: {
       profiler_calls: 0, // Phase 1: no LLM profiler
-      extraction_calls: slowResult.extractedChunks,
+      extraction_calls: slowResult.extractedChunks + slowResult.skippedChunks,
       embedding_calls: 1,
-      total_llm_calls: slowResult.extractedChunks,
+      total_llm_calls:
+        slowResult.extractedChunks + slowResult.skippedChunks,
     },
     timing: {
       parse_ms: parseMs,

--- a/packages/core/src/ingestion/ingest.test.ts
+++ b/packages/core/src/ingestion/ingest.test.ts
@@ -351,12 +351,12 @@ describe('ingest', () => {
     expect(report.status).toMatch(/^completed/);
   });
 
-  it('should report extraction_calls equal to extracted chunks', async () => {
+  it('should report extraction_calls as extracted + skipped chunks', async () => {
     const deps = makeDeps();
     const report = await ingest({ content: makeFiveTurnConversation() }, deps);
 
     expect(report.cost.extraction_calls).toBe(
-      report.chunks.slow_path_extracted,
+      report.chunks.slow_path_extracted + report.chunks.slow_path_skipped,
     );
   });
 

--- a/packages/core/src/ingestion/ingest.test.ts
+++ b/packages/core/src/ingestion/ingest.test.ts
@@ -1,0 +1,382 @@
+import type { EmbeddingProvider, LLMProvider } from '@polyg-mcp/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FalkorDBAdapter } from '../storage/falkordb.js';
+import { ingest } from './index.js';
+import type { ChunkExtraction, IngestionDeps } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Mock setup — combines fast path + slow path + post-process query handling
+// ---------------------------------------------------------------------------
+
+function createMockDb(): FalkorDBAdapter {
+  let nodeCounter = 0;
+  const createdNodes = new Map<
+    string,
+    { uuid: string; label: string; props: Record<string, unknown> }
+  >();
+
+  const mockQuery = vi
+    .fn()
+    .mockImplementation(
+      async (cypher: string, params?: Record<string, unknown>) => {
+        // Entity lookup by UUID (used by getEntity → linkEntities)
+        if (
+          typeof cypher === 'string' &&
+          cypher.includes('E_Entity') &&
+          cypher.includes('{uuid: $id}')
+        ) {
+          const id = params?.id as string;
+          const node = createdNodes.get(id);
+          if (node) {
+            return {
+              records: [
+                { n: { properties: { uuid: node.uuid, ...node.props } } },
+              ],
+              metadata: [],
+            };
+          }
+        }
+
+        // Entity dedup check by name+type (used by addEntity)
+        if (
+          typeof cypher === 'string' &&
+          cypher.includes('E_Entity') &&
+          cypher.includes('{name: $name')
+        ) {
+          const name = params?.name as string;
+          const type = params?.entityType as string;
+          for (const node of createdNodes.values()) {
+            if (
+              node.label === 'E_Entity' &&
+              node.props.name === name &&
+              node.props.entity_type === type
+            ) {
+              return {
+                records: [
+                  { n: { properties: { uuid: node.uuid, ...node.props } } },
+                ],
+                metadata: [],
+              };
+            }
+          }
+        }
+
+        // Causal node lookup by description (used by findOrCreate)
+        if (
+          typeof cypher === 'string' &&
+          cypher.includes('C_Node') &&
+          cypher.includes('toLower')
+        ) {
+          const desc = params?.desc as string;
+          for (const node of createdNodes.values()) {
+            if (
+              node.label === 'C_Node' &&
+              (node.props.description as string).toLowerCase() ===
+                desc?.toLowerCase()
+            ) {
+              return {
+                records: [
+                  { n: { properties: { uuid: node.uuid, ...node.props } } },
+                ],
+                metadata: [],
+              };
+            }
+          }
+        }
+
+        // Post-process: entity fetch for dedup
+        if (
+          typeof cypher === 'string' &&
+          cypher.includes('MATCH (e:E_Entity)') &&
+          cypher.includes('e.uuid AS uuid')
+        ) {
+          const entities: Record<string, unknown>[] = [];
+          for (const node of createdNodes.values()) {
+            if (node.label === 'E_Entity') {
+              entities.push({
+                uuid: node.uuid,
+                name: node.props.name as string,
+                type: node.props.entity_type as string,
+                created_at: node.props.created_at as string,
+                properties: (node.props.properties as string) ?? '{}',
+              });
+            }
+          }
+          return { records: entities, metadata: [] };
+        }
+
+        // Post-process: entity count
+        if (
+          typeof cypher === 'string' &&
+          cypher.includes('MATCH (e:E_Entity)') &&
+          cypher.includes('count(e)')
+        ) {
+          let cnt = 0;
+          for (const node of createdNodes.values()) {
+            if (node.label === 'E_Entity') cnt++;
+          }
+          return { records: [{ cnt }], metadata: [] };
+        }
+
+        // Post-process: causal depth
+        if (typeof cypher === 'string' && cypher.includes('C_CAUSES*')) {
+          return { records: [{ maxDepth: 0 }], metadata: [] };
+        }
+
+        return { records: [], metadata: [] };
+      },
+    );
+
+  return {
+    query: mockQuery,
+    createNode: vi
+      .fn()
+      .mockImplementation((label: string, props: Record<string, unknown>) => {
+        nodeCounter++;
+        const uuid = `uuid-${nodeCounter}`;
+        createdNodes.set(uuid, { uuid, label, props });
+        return Promise.resolve(uuid);
+      }),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  } as unknown as FalkorDBAdapter;
+}
+
+function createMockEmbeddings(): EmbeddingProvider {
+  return {
+    embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+    embedBatch: vi
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map((_, i) => [0.1 * (i + 1), 0.2 * (i + 1)])),
+      ),
+  };
+}
+
+const validExtraction: ChunkExtraction = {
+  entities: [
+    { name: 'Alice', entity_type: 'person' },
+    { name: 'Bob', entity_type: 'person' },
+  ],
+  relationships: [
+    { source: 'Alice', target: 'Bob', relationship_type: 'knows' },
+  ],
+  causal_links: [],
+  facts: [],
+};
+
+function makeDeps(overrides?: { llm?: LLMProvider }): IngestionDeps {
+  const db = createMockDb();
+  return {
+    db,
+    embeddings: createMockEmbeddings(),
+    llm:
+      overrides?.llm ??
+      ({
+        complete: vi.fn().mockResolvedValue(JSON.stringify(validExtraction)),
+      } as unknown as LLMProvider),
+  };
+}
+
+// Valid 5-turn conversation JSON
+function makeFiveTurnConversation(): string {
+  return JSON.stringify([
+    {
+      speaker: 'Alice',
+      text: 'Hey Bob, how are you?',
+      timestamp: '2024-01-15T10:00:00Z',
+    },
+    {
+      speaker: 'Bob',
+      text: 'Good! Just got back from Paris.',
+      timestamp: '2024-01-15T10:01:00Z',
+    },
+    {
+      speaker: 'Alice',
+      text: 'Nice! Did you visit the Louvre?',
+      timestamp: '2024-01-15T10:02:00Z',
+    },
+    {
+      speaker: 'Bob',
+      text: 'Yes! The Mona Lisa was amazing.',
+      timestamp: '2024-01-15T10:03:00Z',
+    },
+    {
+      speaker: 'Alice',
+      text: 'I work at Acme Corp now.',
+      timestamp: '2024-01-15T10:04:00Z',
+    },
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ingest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should complete full pipeline with 5-turn conversation', async () => {
+    const deps = makeDeps();
+    const report = await ingest({ content: makeFiveTurnConversation() }, deps);
+
+    expect(report.status).toMatch(/^completed/);
+    expect(report.chunks.total).toBe(5);
+    expect(report.chunks.parsed).toBe(5);
+    expect(report.chunks.fast_path_written).toBe(5);
+    expect(report.graph.events_created).toBe(5);
+    expect(report.graph.concepts_created).toBe(5);
+    expect(report.timing.total_ms).toBeGreaterThanOrEqual(0);
+    expect(report.timing.parse_ms).toBeGreaterThanOrEqual(0);
+    expect(report.timing.fast_path_ms).toBeGreaterThanOrEqual(0);
+    expect(report.timing.slow_path_ms).toBeGreaterThanOrEqual(0);
+    expect(report.timing.post_process_ms).toBeGreaterThanOrEqual(0);
+    expect(report.cost.embedding_calls).toBe(1);
+  });
+
+  it('should return failed status for empty content', async () => {
+    const deps = makeDeps();
+    const report = await ingest({ content: '' }, deps);
+
+    expect(report.status).toBe('failed');
+    expect(report.quality_warnings).toContainEqual(
+      expect.stringContaining('Empty content'),
+    );
+    expect(report.chunks.total).toBe(0);
+  });
+
+  it('should return failed status for whitespace-only content', async () => {
+    const deps = makeDeps();
+    const report = await ingest({ content: '   \n  ' }, deps);
+
+    expect(report.status).toBe('failed');
+  });
+
+  it('should return failed when parser throws', async () => {
+    const deps = makeDeps();
+    // Invalid JSON that starts with [ but is malformed
+    const report = await ingest({ content: '[{invalid json}]' }, deps);
+
+    expect(report.status).toBe('failed');
+    expect(
+      report.quality_warnings.some((w) => w.includes('Parse failed')),
+    ).toBe(true);
+  });
+
+  it('should populate all IngestionReport fields', async () => {
+    const deps = makeDeps();
+    const report = await ingest({ content: makeFiveTurnConversation() }, deps);
+
+    // Chunks section
+    expect(typeof report.chunks.total).toBe('number');
+    expect(typeof report.chunks.parsed).toBe('number');
+    expect(typeof report.chunks.fast_path_written).toBe('number');
+    expect(typeof report.chunks.slow_path_extracted).toBe('number');
+    expect(typeof report.chunks.slow_path_skipped).toBe('number');
+
+    // Graph section
+    expect(typeof report.graph.entities_created).toBe('number');
+    expect(typeof report.graph.events_created).toBe('number');
+    expect(typeof report.graph.facts_created).toBe('number');
+    expect(typeof report.graph.concepts_created).toBe('number');
+    expect(typeof report.graph.causal_nodes_created).toBe('number');
+    expect(typeof report.graph.causal_links_created).toBe('number');
+    expect(typeof report.graph.cross_links_created).toBe('number');
+    expect(typeof report.graph.relationships_created).toBe('number');
+
+    // Dedup section
+    expect(typeof report.deduplication.mergedEntities).toBe('number');
+    expect(typeof report.deduplication.mergedCausalNodes).toBe('number');
+    expect(typeof report.deduplication.factsWithUpdatedValidity).toBe('number');
+    expect(typeof report.deduplication.orphanedLinksRemoved).toBe('number');
+
+    // Cost section
+    expect(typeof report.cost.profiler_calls).toBe('number');
+    expect(typeof report.cost.extraction_calls).toBe('number');
+    expect(typeof report.cost.embedding_calls).toBe('number');
+    expect(typeof report.cost.total_llm_calls).toBe('number');
+
+    // Timing section
+    expect(typeof report.timing.parse_ms).toBe('number');
+    expect(typeof report.timing.profile_ms).toBe('number');
+    expect(typeof report.timing.fast_path_ms).toBe('number');
+    expect(typeof report.timing.slow_path_ms).toBe('number');
+    expect(typeof report.timing.post_process_ms).toBe('number');
+    expect(typeof report.timing.total_ms).toBe('number');
+  });
+
+  it('should bubble slow path warnings to quality_warnings', async () => {
+    const llm = {
+      complete: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('LLM timeout'))
+        .mockRejectedValueOnce(new Error('LLM timeout')) // retry
+        .mockResolvedValue(JSON.stringify(validExtraction)),
+    } as unknown as LLMProvider;
+
+    const deps = makeDeps({ llm });
+    const report = await ingest({ content: makeFiveTurnConversation() }, deps);
+
+    expect(report.status).toBe('completed_with_warnings');
+    expect(report.quality_warnings.some((w) => w.includes('LLM timeout'))).toBe(
+      true,
+    );
+    expect(report.chunks.slow_path_skipped).toBe(1);
+    expect(report.chunks.slow_path_extracted).toBe(4);
+  });
+
+  it('should accept profileOverride', async () => {
+    const deps = makeDeps();
+    const customProfile = {
+      document_type: 'technical',
+      domain: 'engineering',
+      entity_types_expected: ['component'],
+      relationship_types_expected: ['depends_on'],
+      causal_patterns: ['failure → outage'],
+      temporal_structure: 'explicit_timestamps' as const,
+      extraction_focus: 'Focus on components.',
+      confidence_calibration: {
+        explicit_causation: 1.0,
+        strong_implication: 0.9,
+        weak_inference: 0.7,
+      },
+    };
+
+    const report = await ingest(
+      { content: makeFiveTurnConversation(), profileOverride: customProfile },
+      deps,
+    );
+    expect(report.status).toMatch(/^completed/);
+  });
+
+  it('should report extraction_calls equal to extracted chunks', async () => {
+    const deps = makeDeps();
+    const report = await ingest({ content: makeFiveTurnConversation() }, deps);
+
+    expect(report.cost.extraction_calls).toBe(
+      report.chunks.slow_path_extracted,
+    );
+  });
+
+  it('should track graph stats from slow path', async () => {
+    const deps = makeDeps();
+    const report = await ingest({ content: makeFiveTurnConversation() }, deps);
+
+    // Each of 5 chunks produces 2 entities, 1 relationship from validExtraction
+    expect(report.graph.entities_created).toBeGreaterThan(0);
+    expect(report.graph.relationships_created).toBeGreaterThan(0);
+  });
+
+  it('should handle format override', async () => {
+    const deps = makeDeps();
+    const report = await ingest(
+      { content: makeFiveTurnConversation(), format: 'conversation' },
+      deps,
+    );
+
+    expect(report.status).toMatch(/^completed/);
+    expect(report.chunks.total).toBe(5);
+  });
+});

--- a/packages/core/src/ingestion/post-process.test.ts
+++ b/packages/core/src/ingestion/post-process.test.ts
@@ -490,9 +490,14 @@ describe('checkQuality', () => {
     expect(warnings.some((w) => w.includes('failure rate'))).toBe(true);
   });
 
-  it('should warn when max causal depth < 2', () => {
+  it('should warn when max causal depth < 2 and enough entities', () => {
     const warnings = checkQuality(5, 10, 0, 0, 1);
     expect(warnings.some((w) => w.includes('Shallow causal'))).toBe(true);
+  });
+
+  it('should not warn about causal depth when few entities', () => {
+    const warnings = checkQuality(3, 10, 0, 0, 0);
+    expect(warnings.some((w) => w.includes('Shallow causal'))).toBe(false);
   });
 
   it('should warn when >30% disconnected', () => {
@@ -533,9 +538,10 @@ describe('getQualityMetrics', () => {
       ) {
         return { records: [{ cnt: 10 }], metadata: [] };
       }
+      // Disconnection check: entities not anchored via X_INVOLVES
       if (
         typeof cypher === 'string' &&
-        cypher.includes('NOT (e)-[:E_RELATES]')
+        cypher.includes('NOT (e)<-[:X_INVOLVES]')
       ) {
         return { records: [{ cnt: 3 }], metadata: [] };
       }

--- a/packages/core/src/ingestion/post-process.test.ts
+++ b/packages/core/src/ingestion/post-process.test.ts
@@ -1,0 +1,564 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FalkorDBAdapter } from '../storage/falkordb.js';
+import {
+  checkQuality,
+  getQualityMetrics,
+  normalizeName,
+  runPostProcess,
+} from './post-process.js';
+import type { IngestionDeps } from './types.js';
+
+function createMockDb(): FalkorDBAdapter {
+  return {
+    query: vi.fn().mockResolvedValue({ records: [], metadata: [] }),
+    createNode: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  } as unknown as FalkorDBAdapter;
+}
+
+function makeDeps(db?: FalkorDBAdapter): IngestionDeps {
+  return {
+    db: db ?? createMockDb(),
+    llm: { complete: vi.fn() },
+    embeddings: {
+      embed: vi.fn(),
+      embedBatch: vi.fn(),
+    },
+  } as unknown as IngestionDeps;
+}
+
+// ---------------------------------------------------------------------------
+// normalizeName
+// ---------------------------------------------------------------------------
+
+describe('normalizeName', () => {
+  it('should lowercase', () => {
+    expect(normalizeName('Alice')).toBe('alice');
+  });
+
+  it('should collapse hyphens to spaces', () => {
+    expect(normalizeName('Alice-Smith')).toBe('alice smith');
+  });
+
+  it('should collapse underscores to spaces', () => {
+    expect(normalizeName('alice_smith')).toBe('alice smith');
+  });
+
+  it('should collapse multiple spaces', () => {
+    expect(normalizeName('  alice   smith  ')).toBe('alice smith');
+  });
+
+  it('should handle mixed separators', () => {
+    expect(normalizeName('Alice-Bob_Smith  Jr')).toBe('alice bob smith jr');
+  });
+
+  it('should handle empty string', () => {
+    expect(normalizeName('')).toBe('');
+  });
+
+  it('should handle already normalized name', () => {
+    expect(normalizeName('alice')).toBe('alice');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deduplicateEntities (via runPostProcess)
+// ---------------------------------------------------------------------------
+
+describe('deduplicateEntities', () => {
+  let db: FalkorDBAdapter;
+
+  beforeEach(() => {
+    db = createMockDb();
+    vi.clearAllMocks();
+  });
+
+  it('should merge duplicate entities with same normalized name and type', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      // Entity fetch query
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('MATCH (e:E_Entity)') &&
+        cypher.includes('RETURN')
+      ) {
+        return {
+          records: [
+            {
+              uuid: 'id-1',
+              name: 'Alice',
+              type: 'person',
+              created_at: '2024-01-01T00:00:00Z',
+              properties: '{}',
+            },
+            {
+              uuid: 'id-2',
+              name: 'alice',
+              type: 'person',
+              created_at: '2024-01-02T00:00:00Z',
+              properties: '{}',
+            },
+            {
+              uuid: 'id-3',
+              name: 'Bob',
+              type: 'person',
+              created_at: '2024-01-01T00:00:00Z',
+              properties: '{}',
+            },
+          ],
+          metadata: [],
+        };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const deps = makeDeps(db);
+    const result = await runPostProcess(deps);
+    expect(result.mergedEntities).toBe(1);
+  });
+
+  it('should pick earliest created_at as canonical', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('MATCH (e:E_Entity)') &&
+        cypher.includes('RETURN')
+      ) {
+        return {
+          records: [
+            {
+              uuid: 'newer',
+              name: 'Alice',
+              type: 'person',
+              created_at: '2024-06-01T00:00:00Z',
+              properties: '{}',
+            },
+            {
+              uuid: 'older',
+              name: 'alice',
+              type: 'person',
+              created_at: '2024-01-01T00:00:00Z',
+              properties: '{}',
+            },
+          ],
+          metadata: [],
+        };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const deps = makeDeps(db);
+    await runPostProcess(deps);
+
+    // The DETACH DELETE should target 'newer' (the non-canonical)
+    const deleteCalls = vi
+      .mocked(db.query)
+      .mock.calls.filter(
+        ([cypher]) =>
+          typeof cypher === 'string' && cypher.includes('DETACH DELETE'),
+      );
+    expect(deleteCalls.length).toBe(1);
+    const params = deleteCalls[0][1] as Record<string, unknown>;
+    expect(params.dupId).toBe('newer');
+  });
+
+  it('should not merge entities with different types', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('MATCH (e:E_Entity)') &&
+        cypher.includes('RETURN')
+      ) {
+        return {
+          records: [
+            {
+              uuid: 'id-1',
+              name: 'Alice',
+              type: 'person',
+              created_at: '2024-01-01T00:00:00Z',
+              properties: '{}',
+            },
+            {
+              uuid: 'id-2',
+              name: 'Alice',
+              type: 'organization',
+              created_at: '2024-01-02T00:00:00Z',
+              properties: '{}',
+            },
+          ],
+          metadata: [],
+        };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const deps = makeDeps(db);
+    const result = await runPostProcess(deps);
+    expect(result.mergedEntities).toBe(0);
+  });
+
+  it('should handle no duplicates', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('MATCH (e:E_Entity)') &&
+        cypher.includes('RETURN')
+      ) {
+        return {
+          records: [
+            {
+              uuid: 'id-1',
+              name: 'Alice',
+              type: 'person',
+              created_at: '2024-01-01T00:00:00Z',
+              properties: '{}',
+            },
+            {
+              uuid: 'id-2',
+              name: 'Bob',
+              type: 'person',
+              created_at: '2024-01-01T00:00:00Z',
+              properties: '{}',
+            },
+          ],
+          metadata: [],
+        };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const deps = makeDeps(db);
+    const result = await runPostProcess(deps);
+    expect(result.mergedEntities).toBe(0);
+  });
+
+  it('should merge properties with canonical winning on conflict', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('MATCH (e:E_Entity)') &&
+        cypher.includes('RETURN')
+      ) {
+        return {
+          records: [
+            {
+              uuid: 'id-1',
+              name: 'Alice',
+              type: 'person',
+              created_at: '2024-01-01T00:00:00Z',
+              properties: '{"role":"engineer","team":"alpha"}',
+            },
+            {
+              uuid: 'id-2',
+              name: 'alice',
+              type: 'person',
+              created_at: '2024-01-02T00:00:00Z',
+              properties: '{"role":"manager","city":"NYC"}',
+            },
+          ],
+          metadata: [],
+        };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const deps = makeDeps(db);
+    await runPostProcess(deps);
+
+    // Verify properties merge — canonical's "role" should win
+    const propsCalls = vi
+      .mocked(db.query)
+      .mock.calls.filter(
+        ([cypher]) =>
+          typeof cypher === 'string' && cypher.includes('SET e.properties'),
+      );
+    expect(propsCalls.length).toBe(1);
+    const params = propsCalls[0][1] as Record<string, unknown>;
+    const merged = JSON.parse(params.props as string);
+    expect(merged.role).toBe('engineer'); // canonical wins
+    expect(merged.city).toBe('NYC'); // dup's unique key preserved
+    expect(merged.team).toBe('alpha'); // canonical's unique key preserved
+  });
+
+  it('should merge hyphen vs underscore variants', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('MATCH (e:E_Entity)') &&
+        cypher.includes('RETURN')
+      ) {
+        return {
+          records: [
+            {
+              uuid: 'id-1',
+              name: 'auth-service',
+              type: 'service',
+              created_at: '2024-01-01T00:00:00Z',
+              properties: '{}',
+            },
+            {
+              uuid: 'id-2',
+              name: 'auth_service',
+              type: 'service',
+              created_at: '2024-01-02T00:00:00Z',
+              properties: '{}',
+            },
+          ],
+          metadata: [],
+        };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const deps = makeDeps(db);
+    const result = await runPostProcess(deps);
+    expect(result.mergedEntities).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveFactConflicts (via runPostProcess)
+// ---------------------------------------------------------------------------
+
+describe('resolveFactConflicts', () => {
+  let db: FalkorDBAdapter;
+
+  beforeEach(() => {
+    db = createMockDb();
+    vi.clearAllMocks();
+  });
+
+  it('should cap earlier fact valid_to when later fact overlaps', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('f1.valid_from < f2.valid_from')
+      ) {
+        return {
+          records: [
+            {
+              f1_uuid: 'fact-1',
+              f2_valid_from: '2024-06-01T00:00:00Z',
+            },
+          ],
+          metadata: [],
+        };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const deps = makeDeps(db);
+    const result = await runPostProcess(deps);
+    expect(result.factsWithUpdatedValidity).toBe(1);
+
+    // Verify SET was called with correct valid_to
+    const setCalls = vi
+      .mocked(db.query)
+      .mock.calls.filter(
+        ([cypher]) =>
+          typeof cypher === 'string' && cypher.includes('SET f.valid_to'),
+      );
+    expect(setCalls.length).toBe(1);
+    const params = setCalls[0][1] as Record<string, unknown>;
+    expect(params.validTo).toBe('2024-06-01T00:00:00Z');
+  });
+
+  it('should handle no overlapping facts', async () => {
+    const deps = makeDeps(db);
+    const result = await runPostProcess(deps);
+    expect(result.factsWithUpdatedValidity).toBe(0);
+  });
+
+  it('should deduplicate updates for same fact appearing in multiple pairs', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('f1.valid_from < f2.valid_from')
+      ) {
+        return {
+          records: [
+            { f1_uuid: 'fact-1', f2_valid_from: '2024-06-01T00:00:00Z' },
+            { f1_uuid: 'fact-1', f2_valid_from: '2024-07-01T00:00:00Z' },
+          ],
+          metadata: [],
+        };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const deps = makeDeps(db);
+    const result = await runPostProcess(deps);
+
+    // Should only update fact-1 once (first match)
+    expect(result.factsWithUpdatedValidity).toBe(1);
+    const setCalls = vi
+      .mocked(db.query)
+      .mock.calls.filter(
+        ([cypher]) =>
+          typeof cypher === 'string' && cypher.includes('SET f.valid_to'),
+      );
+    expect(setCalls.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanupOrphans (via runPostProcess)
+// ---------------------------------------------------------------------------
+
+describe('cleanupOrphans', () => {
+  let db: FalkorDBAdapter;
+
+  beforeEach(() => {
+    db = createMockDb();
+    vi.clearAllMocks();
+  });
+
+  it('should delete entities with zero edges', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('NOT (e)-[:E_RELATES]') &&
+        cypher.includes('count')
+      ) {
+        return { records: [{ orphanCount: 3 }], metadata: [] };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const deps = makeDeps(db);
+    const result = await runPostProcess(deps);
+    expect(result.orphanedLinksRemoved).toBe(3);
+
+    // Verify DELETE was called
+    const deleteCalls = vi
+      .mocked(db.query)
+      .mock.calls.filter(
+        ([cypher]) =>
+          typeof cypher === 'string' &&
+          cypher.includes('NOT (e)-[:E_RELATES]') &&
+          cypher.includes('DELETE'),
+      );
+    expect(deleteCalls.length).toBe(1);
+  });
+
+  it('should skip delete when no orphans exist', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('NOT (e)-[:E_RELATES]') &&
+        cypher.includes('count')
+      ) {
+        return { records: [{ orphanCount: 0 }], metadata: [] };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const deps = makeDeps(db);
+    const result = await runPostProcess(deps);
+    expect(result.orphanedLinksRemoved).toBe(0);
+
+    // DELETE should NOT be called
+    const deleteCalls = vi
+      .mocked(db.query)
+      .mock.calls.filter(
+        ([cypher]) =>
+          typeof cypher === 'string' &&
+          cypher.includes('NOT (e)-[:E_RELATES]') &&
+          cypher.includes('DELETE e'),
+      );
+    expect(deleteCalls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkQuality
+// ---------------------------------------------------------------------------
+
+describe('checkQuality', () => {
+  it('should warn when entity count < 3', () => {
+    const warnings = checkQuality(2, 10, 0, 0, 3);
+    expect(warnings.some((w) => w.includes('Low entity count'))).toBe(true);
+  });
+
+  it('should warn when entity count > 2x chunks', () => {
+    const warnings = checkQuality(30, 10, 0, 0, 3);
+    expect(warnings.some((w) => w.includes('High entity count'))).toBe(true);
+  });
+
+  it('should warn when >20% chunks failed extraction', () => {
+    const warnings = checkQuality(5, 10, 3, 0, 3);
+    expect(warnings.some((w) => w.includes('failure rate'))).toBe(true);
+  });
+
+  it('should warn when max causal depth < 2', () => {
+    const warnings = checkQuality(5, 10, 0, 0, 1);
+    expect(warnings.some((w) => w.includes('Shallow causal'))).toBe(true);
+  });
+
+  it('should warn when >30% disconnected', () => {
+    const warnings = checkQuality(10, 10, 0, 0.4, 3);
+    expect(warnings.some((w) => w.includes('disconnection'))).toBe(true);
+  });
+
+  it('should return empty array when all checks pass', () => {
+    const warnings = checkQuality(5, 10, 1, 0.1, 3);
+    expect(warnings).toEqual([]);
+  });
+
+  it('should handle 0 chunks without division errors', () => {
+    const warnings = checkQuality(0, 0, 0, 0, 0);
+    expect(warnings).toBeInstanceOf(Array);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getQualityMetrics
+// ---------------------------------------------------------------------------
+
+describe('getQualityMetrics', () => {
+  let db: FalkorDBAdapter;
+
+  beforeEach(() => {
+    db = createMockDb();
+    vi.clearAllMocks();
+  });
+
+  it('should return entity count, disconnected ratio, and max causal depth', async () => {
+    vi.mocked(db.query).mockImplementation(async (cypher: string) => {
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('MATCH (e:E_Entity)') &&
+        cypher.includes('count(e)') &&
+        !cypher.includes('NOT')
+      ) {
+        return { records: [{ cnt: 10 }], metadata: [] };
+      }
+      if (
+        typeof cypher === 'string' &&
+        cypher.includes('NOT (e)-[:E_RELATES]')
+      ) {
+        return { records: [{ cnt: 3 }], metadata: [] };
+      }
+      if (typeof cypher === 'string' && cypher.includes('C_CAUSES')) {
+        return { records: [{ maxDepth: 4 }], metadata: [] };
+      }
+      return { records: [], metadata: [] };
+    });
+
+    const deps = makeDeps(db);
+    const metrics = await getQualityMetrics(deps);
+
+    expect(metrics.entityCount).toBe(10);
+    expect(metrics.disconnectedRatio).toBeCloseTo(0.3);
+    expect(metrics.maxCausalDepth).toBe(4);
+  });
+
+  it('should handle empty graph', async () => {
+    const deps = makeDeps(db);
+    const metrics = await getQualityMetrics(deps);
+
+    expect(metrics.entityCount).toBe(0);
+    expect(metrics.disconnectedRatio).toBe(0);
+    expect(metrics.maxCausalDepth).toBe(0);
+  });
+});

--- a/packages/core/src/ingestion/post-process.ts
+++ b/packages/core/src/ingestion/post-process.ts
@@ -1,0 +1,325 @@
+// Post-processing — entity dedup, fact conflict resolution, orphan cleanup, quality checks
+import type { DeduplicationResult, IngestionDeps } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Name normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize an entity name for deduplication grouping.
+ * Stricter than slow-path's `normalizeEntityKey` (which only lowercases + trims)
+ * because cross-chunk duplicates may use hyphens vs underscores vs spaces.
+ */
+export function normalizeName(name: string): string {
+  return name.toLowerCase().replace(/[-_]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+// ---------------------------------------------------------------------------
+// Entity deduplication
+// ---------------------------------------------------------------------------
+
+interface RawEntity {
+  uuid: string;
+  name: string;
+  type: string;
+  created_at: string;
+  properties: string;
+}
+
+async function deduplicateEntities(deps: IngestionDeps): Promise<number> {
+  // 1. Fetch all entities
+  const result = await deps.db.query(
+    `MATCH (e:E_Entity)
+     RETURN e.uuid AS uuid, e.name AS name, e.entity_type AS type,
+            e.created_at AS created_at, e.properties AS properties`,
+  );
+
+  const entities: RawEntity[] = result.records.map(
+    (r: Record<string, unknown>) => ({
+      uuid: r.uuid as string,
+      name: r.name as string,
+      type: r.type as string,
+      created_at: (r.created_at as string) ?? '',
+      properties: (r.properties as string) ?? '{}',
+    }),
+  );
+
+  // 2. Group by normalized name + type
+  const groups = new Map<string, RawEntity[]>();
+  for (const ent of entities) {
+    const key = `${normalizeName(ent.name)}::${ent.type}`;
+    const group = groups.get(key);
+    if (group) {
+      group.push(ent);
+    } else {
+      groups.set(key, [ent]);
+    }
+  }
+
+  // 3. Merge each group with >1 member
+  let merged = 0;
+  for (const group of groups.values()) {
+    if (group.length <= 1) continue;
+
+    // Pick canonical: earliest created_at
+    group.sort((a, b) => a.created_at.localeCompare(b.created_at));
+    const canonical = group[0];
+    const duplicates = group.slice(1);
+
+    for (const dup of duplicates) {
+      await mergeEntityInto(deps, canonical, dup);
+      merged++;
+    }
+  }
+
+  return merged;
+}
+
+async function mergeEntityInto(
+  deps: IngestionDeps,
+  canonical: RawEntity,
+  dup: RawEntity,
+): Promise<void> {
+  // Merge properties into canonical (canonical wins on conflict)
+  const canonProps = safeJsonParse(canonical.properties);
+  const dupProps = safeJsonParse(dup.properties);
+  const merged = { ...dupProps, ...canonProps };
+  await deps.db.query(
+    `MATCH (e:E_Entity {uuid: $canonId}) SET e.properties = $props`,
+    { canonId: canonical.uuid, props: JSON.stringify(merged) },
+  );
+
+  // Move E_RELATES edges (outgoing) — guard self-loops
+  await deps.db.query(
+    `MATCH (dup:E_Entity {uuid: $dupId})-[r:E_RELATES]->(target:E_Entity)
+     WHERE target.uuid <> $canonId
+     MERGE (canon:E_Entity {uuid: $canonId})-[:E_RELATES {relationship_type: r.relationship_type}]->(target)
+     DELETE r`,
+    { dupId: dup.uuid, canonId: canonical.uuid },
+  );
+
+  // Move E_RELATES edges (incoming) — guard self-loops
+  await deps.db.query(
+    `MATCH (source:E_Entity)-[r:E_RELATES]->(dup:E_Entity {uuid: $dupId})
+     WHERE source.uuid <> $canonId
+     MERGE (source)-[:E_RELATES {relationship_type: r.relationship_type}]->(canon:E_Entity {uuid: $canonId})
+     DELETE r`,
+    { dupId: dup.uuid, canonId: canonical.uuid },
+  );
+
+  // Move X_REPRESENTS (S_Concept → E_Entity)
+  await deps.db.query(
+    `MATCH (concept:S_Concept)-[r:X_REPRESENTS]->(dup:E_Entity {uuid: $dupId})
+     MERGE (concept)-[:X_REPRESENTS]->(canon:E_Entity {uuid: $canonId})
+     DELETE r`,
+    { dupId: dup.uuid, canonId: canonical.uuid },
+  );
+
+  // Move X_INVOLVES (T_Event / T_Fact → E_Entity)
+  await deps.db.query(
+    `MATCH (event)-[r:X_INVOLVES]->(dup:E_Entity {uuid: $dupId})
+     MERGE (event)-[:X_INVOLVES]->(canon:E_Entity {uuid: $canonId})
+     DELETE r`,
+    { dupId: dup.uuid, canonId: canonical.uuid },
+  );
+
+  // Move X_AFFECTS (C_Node → E_Entity)
+  await deps.db.query(
+    `MATCH (causal:C_Node)-[r:X_AFFECTS]->(dup:E_Entity {uuid: $dupId})
+     MERGE (causal)-[:X_AFFECTS]->(canon:E_Entity {uuid: $canonId})
+     DELETE r`,
+    { dupId: dup.uuid, canonId: canonical.uuid },
+  );
+
+  // Delete the duplicate
+  await deps.db.query(`MATCH (dup:E_Entity {uuid: $dupId}) DETACH DELETE dup`, {
+    dupId: dup.uuid,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fact conflict resolution
+// ---------------------------------------------------------------------------
+
+async function resolveFactConflicts(deps: IngestionDeps): Promise<number> {
+  // Find overlapping fact pairs: same (subject, predicate), earlier has open/overlapping validity
+  const result = await deps.db.query(
+    `MATCH (f1:T_Fact), (f2:T_Fact)
+     WHERE f1.subject = f2.subject
+       AND f1.predicate = f2.predicate
+       AND f1.uuid <> f2.uuid
+       AND f1.valid_from < f2.valid_from
+       AND (f1.valid_to IS NULL OR f1.valid_to >= f2.valid_from)
+     RETURN f1.uuid AS f1_uuid, f2.valid_from AS f2_valid_from`,
+  );
+
+  // Deduplicate: a fact may appear in multiple pairs, only update once
+  const updated = new Set<string>();
+  for (const record of result.records) {
+    const f1Uuid = record.f1_uuid as string;
+    if (updated.has(f1Uuid)) continue;
+
+    await deps.db.query(
+      `MATCH (f:T_Fact {uuid: $uuid}) SET f.valid_to = $validTo`,
+      { uuid: f1Uuid, validTo: record.f2_valid_from as string },
+    );
+    updated.add(f1Uuid);
+  }
+
+  return updated.size;
+}
+
+// ---------------------------------------------------------------------------
+// Orphan cleanup
+// ---------------------------------------------------------------------------
+
+async function cleanupOrphans(deps: IngestionDeps): Promise<number> {
+  // Two-step: count first, then delete (FalkorDB may not support RETURN after DELETE)
+  const countResult = await deps.db.query(
+    `MATCH (e:E_Entity)
+     WHERE NOT (e)-[:E_RELATES]-()
+       AND NOT (e)<-[:X_REPRESENTS]-()
+       AND NOT (e)<-[:X_INVOLVES]-()
+       AND NOT (e)<-[:X_AFFECTS]-()
+     RETURN count(e) AS orphanCount`,
+  );
+  const orphanCount = asNumber(countResult.records[0]?.orphanCount) ?? 0;
+
+  if (orphanCount > 0) {
+    await deps.db.query(
+      `MATCH (e:E_Entity)
+       WHERE NOT (e)-[:E_RELATES]-()
+         AND NOT (e)<-[:X_REPRESENTS]-()
+         AND NOT (e)<-[:X_INVOLVES]-()
+         AND NOT (e)<-[:X_AFFECTS]-()
+       DELETE e`,
+    );
+  }
+
+  return orphanCount;
+}
+
+// ---------------------------------------------------------------------------
+// Quality checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure function — returns warning strings based on graph metrics.
+ */
+export function checkQuality(
+  entityCount: number,
+  chunkCount: number,
+  failedChunkCount: number,
+  disconnectedRatio: number,
+  maxCausalDepth: number,
+): string[] {
+  const warnings: string[] = [];
+
+  if (entityCount < 3) {
+    warnings.push(
+      `Low entity count: ${entityCount} entities extracted (expected >= 3)`,
+    );
+  }
+
+  if (chunkCount > 0 && entityCount > 2 * chunkCount) {
+    warnings.push(
+      `High entity count: ${entityCount} entities from ${chunkCount} chunks (> 2x ratio)`,
+    );
+  }
+
+  if (chunkCount > 0 && failedChunkCount / chunkCount > 0.2) {
+    warnings.push(
+      `High extraction failure rate: ${failedChunkCount}/${chunkCount} chunks failed (> 20%)`,
+    );
+  }
+
+  if (maxCausalDepth < 2) {
+    warnings.push(
+      `Shallow causal chains: max depth ${maxCausalDepth} (expected >= 2)`,
+    );
+  }
+
+  if (disconnectedRatio > 0.3) {
+    warnings.push(
+      `High disconnection rate: ${Math.round(disconnectedRatio * 100)}% of entities are disconnected (> 30%)`,
+    );
+  }
+
+  return warnings;
+}
+
+/**
+ * Gather quality metrics from the graph via Cypher queries.
+ */
+export async function getQualityMetrics(deps: IngestionDeps): Promise<{
+  entityCount: number;
+  disconnectedRatio: number;
+  maxCausalDepth: number;
+}> {
+  const entityResult = await deps.db.query(
+    `MATCH (e:E_Entity) RETURN count(e) AS cnt`,
+  );
+  const entityCount = asNumber(entityResult.records[0]?.cnt) ?? 0;
+
+  let disconnectedRatio = 0;
+  if (entityCount > 0) {
+    const disconnectedResult = await deps.db.query(
+      `MATCH (e:E_Entity)
+       WHERE NOT (e)-[:E_RELATES]-()
+         AND NOT (e)<-[:X_REPRESENTS]-()
+         AND NOT (e)<-[:X_INVOLVES]-()
+         AND NOT (e)<-[:X_AFFECTS]-()
+       RETURN count(e) AS cnt`,
+    );
+    const disconnected = asNumber(disconnectedResult.records[0]?.cnt) ?? 0;
+    disconnectedRatio = disconnected / entityCount;
+  }
+
+  const depthResult = await deps.db.query(
+    `MATCH p = (a:C_Node)-[:C_CAUSES*1..20]->(b:C_Node)
+     RETURN max(length(p)) AS maxDepth`,
+  );
+  const maxCausalDepth = asNumber(depthResult.records[0]?.maxDepth) ?? 0;
+
+  return { entityCount, disconnectedRatio, maxCausalDepth };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+export async function runPostProcess(
+  deps: IngestionDeps,
+): Promise<DeduplicationResult> {
+  const mergedEntities = await deduplicateEntities(deps);
+  const factsWithUpdatedValidity = await resolveFactConflicts(deps);
+  const orphanedLinksRemoved = await cleanupOrphans(deps);
+
+  return {
+    mergedEntities,
+    mergedCausalNodes: 0, // deferred to future work
+    factsWithUpdatedValidity,
+    orphanedLinksRemoved,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function safeJsonParse(s: string): Record<string, unknown> {
+  try {
+    return JSON.parse(s) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function asNumber(val: unknown): number | undefined {
+  if (typeof val === 'number') return val;
+  if (typeof val === 'string') {
+    const n = Number(val);
+    return Number.isNaN(n) ? undefined : n;
+  }
+  return undefined;
+}

--- a/packages/core/src/ingestion/post-process.ts
+++ b/packages/core/src/ingestion/post-process.ts
@@ -150,6 +150,7 @@ async function resolveFactConflicts(deps: IngestionDeps): Promise<number> {
        AND f1.uuid <> f2.uuid
        AND f1.valid_from < f2.valid_from
        AND (f1.valid_to IS NULL OR f1.valid_to >= f2.valid_from)
+     ORDER BY f2.valid_from ASC
      RETURN f1.uuid AS f1_uuid, f2.valid_from AS f2_valid_from`,
   );
 

--- a/packages/core/src/ingestion/post-process.ts
+++ b/packages/core/src/ingestion/post-process.ts
@@ -233,7 +233,7 @@ export function checkQuality(
     );
   }
 
-  if (maxCausalDepth < 2) {
+  if (entityCount >= 5 && maxCausalDepth < 2) {
     warnings.push(
       `Shallow causal chains: max depth ${maxCausalDepth} (expected >= 2)`,
     );
@@ -261,14 +261,14 @@ export async function getQualityMetrics(deps: IngestionDeps): Promise<{
   );
   const entityCount = asNumber(entityResult.records[0]?.cnt) ?? 0;
 
+  // Disconnection: entities not anchored to the temporal backbone via X_INVOLVES.
+  // Better than zero-edge check — catches small islands (entities linked only to
+  // each other via E_RELATES but not to any T_Event or T_Fact).
   let disconnectedRatio = 0;
   if (entityCount > 0) {
     const disconnectedResult = await deps.db.query(
       `MATCH (e:E_Entity)
-       WHERE NOT (e)-[:E_RELATES]-()
-         AND NOT (e)<-[:X_REPRESENTS]-()
-         AND NOT (e)<-[:X_INVOLVES]-()
-         AND NOT (e)<-[:X_AFFECTS]-()
+       WHERE NOT (e)<-[:X_INVOLVES]-()
        RETURN count(e) AS cnt`,
     );
     const disconnected = asNumber(disconnectedResult.records[0]?.cnt) ?? 0;


### PR DESCRIPTION
## Summary

- **Post-processing** (`post-process.ts`): Entity deduplication (normalize names, merge duplicates, re-point edges), fact conflict resolution (cap `valid_to` on superseded facts), orphan cleanup (delete zero-edge entities), quality checks (entity count, failure rate, causal depth, disconnection ratio)
- **Pipeline orchestrator** (`index.ts`): Public `ingest(input, deps)` API that wires parse → profile → fast path → slow path → post-process → quality checks into a single `IngestionReport`
- **Core exports**: `ingest()` and all ingestion types exported from `@polyg-mcp/core`

Completes Phase 1 of the ingestion pipeline (PR C per the implementation plan).

## Test plan

- [x] 27 post-process tests: normalizeName, entity dedup (merge, canonical selection, property merging, hyphen/underscore variants), fact conflicts, orphan cleanup, quality checks
- [x] 10 orchestrator tests: full 5-turn conversation pipeline, empty/whitespace content, parse failure, warning bubbling, profileOverride, report field population
- [x] 649 total tests passing, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)