### PR TITLE
feat: ingestion Phase 2 — text parser, structured parser, LLM profiler

### DIFF
--- a/packages/core/src/ingestion/extraction-prompt.test.ts
+++ b/packages/core/src/ingestion/extraction-prompt.test.ts
@@ -292,6 +292,24 @@ describe('buildExtractionPrompt', () => {
       );
     });
 
+    it('should include extra metadata in chunk info', () => {
+      const chunkWithExtra: ParsedChunk = {
+        ...testChunk,
+        metadata: {
+          ...testChunk.metadata,
+          extra: { level: 'error', id: 42 },
+        },
+      };
+      const { user } = buildExtractionPrompt(
+        chunkWithExtra,
+        testProfile,
+        emptyNeighborhood,
+        10,
+      );
+      expect(user).toContain('level: error');
+      expect(user).toContain('id: 42');
+    });
+
     it('should omit occurred_at when not present in events', () => {
       const neighborhoodNoDate: NeighborhoodContext = {
         ...emptyNeighborhood,

--- a/packages/core/src/ingestion/extraction-prompt.test.ts
+++ b/packages/core/src/ingestion/extraction-prompt.test.ts
@@ -163,7 +163,7 @@ describe('buildExtractionPrompt', () => {
       );
     });
 
-    it('should not include neighborhood data when neighborhood is empty', () => {
+    it('should not include neighborhood data or graph header when neighborhood is empty', () => {
       const { user } = buildExtractionPrompt(
         testChunk,
         testProfile,
@@ -174,8 +174,19 @@ describe('buildExtractionPrompt', () => {
       expect(user).not.toContain('Recent events');
       expect(user).not.toContain('Active causal chains');
       expect(user).not.toContain('Related concepts');
+      expect(user).not.toContain('Context from existing graph:');
       // Chunk info is always present
       expect(user).toContain('Chunk info:');
+    });
+
+    it('should show graph header only when neighborhood has data', () => {
+      const { user } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        richNeighborhood,
+        10,
+      );
+      expect(user).toContain('Context from existing graph:');
     });
 
     it('should include known entities when available', () => {
@@ -308,6 +319,25 @@ describe('buildExtractionPrompt', () => {
       );
       expect(user).toContain('level: error');
       expect(user).toContain('id: 42');
+    });
+
+    it('should truncate long extra metadata values', () => {
+      const longValue = 'x'.repeat(300);
+      const chunkWithLongExtra: ParsedChunk = {
+        ...testChunk,
+        metadata: {
+          ...testChunk.metadata,
+          extra: { data: longValue },
+        },
+      };
+      const { user } = buildExtractionPrompt(
+        chunkWithLongExtra,
+        testProfile,
+        emptyNeighborhood,
+        10,
+      );
+      expect(user).not.toContain(longValue);
+      expect(user).toContain('x'.repeat(200) + '...');
     });
 
     it('should omit occurred_at when not present in events', () => {

--- a/packages/core/src/ingestion/extraction-prompt.test.ts
+++ b/packages/core/src/ingestion/extraction-prompt.test.ts
@@ -66,6 +66,7 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         emptyNeighborhood,
+        10,
       );
       expect(system).toContain('Document type: conversation');
       expect(system).toContain('Domain: general');
@@ -76,6 +77,7 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         emptyNeighborhood,
+        10,
       );
       expect(system).toContain('person, place, organization');
     });
@@ -85,6 +87,7 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         emptyNeighborhood,
+        10,
       );
       expect(system).toContain('knows, works_at');
     });
@@ -94,6 +97,7 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         emptyNeighborhood,
+        10,
       );
       expect(system).toContain('decision → action');
       expect(system).toContain('event → reaction');
@@ -104,6 +108,7 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         emptyNeighborhood,
+        10,
       );
       expect(system).toContain('Explicit causation');
       expect(system).toContain('1');
@@ -116,6 +121,7 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         emptyNeighborhood,
+        10,
       );
       expect(system).toContain('Focus on people and their relationships.');
     });
@@ -125,6 +131,7 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         emptyNeighborhood,
+        10,
       );
       expect(system).toContain('"entities"');
       expect(system).toContain('"relationships"');
@@ -137,6 +144,7 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         emptyNeighborhood,
+        10,
       );
       expect(system).toContain('REUSE the exact same name');
     });
@@ -148,20 +156,26 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         emptyNeighborhood,
+        10,
       );
       expect(user).toContain(
         'Alice: I just started working at Acme Corp last week.',
       );
     });
 
-    it('should not include context section when neighborhood is empty', () => {
+    it('should not include neighborhood data when neighborhood is empty', () => {
       const { user } = buildExtractionPrompt(
         testChunk,
         testProfile,
         emptyNeighborhood,
+        10,
       );
-      expect(user).not.toContain('Context from existing graph');
       expect(user).not.toContain('Known entities');
+      expect(user).not.toContain('Recent events');
+      expect(user).not.toContain('Active causal chains');
+      expect(user).not.toContain('Related concepts');
+      // Chunk info is always present
+      expect(user).toContain('Chunk info:');
     });
 
     it('should include known entities when available', () => {
@@ -169,6 +183,7 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         richNeighborhood,
+        10,
       );
       expect(user).toContain(
         'Known entities: Alice (person), Acme Corp (organization)',
@@ -180,8 +195,11 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         richNeighborhood,
+        10,
       );
-      expect(user).toContain('Recent events: Alice mentioned job search');
+      expect(user).toContain(
+        'Alice mentioned job search (2024-01-15T10:00:00Z)',
+      );
     });
 
     it('should include causal chains when available', () => {
@@ -189,6 +207,7 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         richNeighborhood,
+        10,
       );
       expect(user).toContain(
         'Active causal chains: Job search → Got hired (0.9)',
@@ -200,8 +219,135 @@ describe('buildExtractionPrompt', () => {
         testChunk,
         testProfile,
         richNeighborhood,
+        10,
       );
       expect(user).toContain('Related concepts: Employment, Career change');
+    });
+
+    it('should include chunk position and total', () => {
+      const { user } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+        10,
+      );
+      expect(user).toContain('Chunk 4 of 10');
+    });
+
+    it('should include speaker metadata', () => {
+      const { user } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+        10,
+      );
+      expect(user).toContain('Speaker: Alice');
+    });
+
+    it('should include section metadata for text chunks', () => {
+      const textChunk: ParsedChunk = {
+        chunk_id: 'chunk_000',
+        content: 'Introduction to the topic.',
+        position: 0,
+        metadata: {
+          source_format: 'text',
+          section: 'Introduction',
+        },
+      };
+      const { user } = buildExtractionPrompt(
+        textChunk,
+        testProfile,
+        emptyNeighborhood,
+        5,
+      );
+      expect(user).toContain('Section: Introduction');
+    });
+
+    it('should include timestamp when present', () => {
+      const chunkWithTimestamp: ParsedChunk = {
+        ...testChunk,
+        metadata: {
+          ...testChunk.metadata,
+          timestamp: '2024-01-15T10:00:00Z',
+        },
+      };
+      const { user } = buildExtractionPrompt(
+        chunkWithTimestamp,
+        testProfile,
+        emptyNeighborhood,
+        10,
+      );
+      expect(user).toContain('Timestamp: 2024-01-15T10:00:00Z');
+    });
+
+    it('should include occurred_at in recent events', () => {
+      const { user } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        richNeighborhood,
+        10,
+      );
+      expect(user).toContain(
+        'Alice mentioned job search (2024-01-15T10:00:00Z)',
+      );
+    });
+
+    it('should omit occurred_at when not present in events', () => {
+      const neighborhoodNoDate: NeighborhoodContext = {
+        ...emptyNeighborhood,
+        recentEvents: [{ description: 'Something happened', occurred_at: '' }],
+      };
+      const { user } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        neighborhoodNoDate,
+        10,
+      );
+      expect(user).toContain('Recent events: Something happened');
+      expect(user).not.toContain('Something happened (');
+    });
+  });
+
+  describe('system prompt — temporal guidance', () => {
+    it('should include temporal_structure guidance for session_ordered', () => {
+      const { system } = buildExtractionPrompt(
+        testChunk,
+        testProfile,
+        emptyNeighborhood,
+        10,
+      );
+      expect(system).toContain('Temporal structure: session_ordered');
+      expect(system).toContain('chronologically ordered');
+    });
+
+    it('should include temporal_structure guidance for explicit_timestamps', () => {
+      const explicitProfile: DocumentProfile = {
+        ...testProfile,
+        temporal_structure: 'explicit_timestamps',
+      };
+      const { system } = buildExtractionPrompt(
+        testChunk,
+        explicitProfile,
+        emptyNeighborhood,
+        10,
+      );
+      expect(system).toContain('Temporal structure: explicit_timestamps');
+      expect(system).toContain('Use timestamps for fact valid_from/valid_to');
+    });
+
+    it('should include temporal_structure guidance for implicit', () => {
+      const implicitProfile: DocumentProfile = {
+        ...testProfile,
+        temporal_structure: 'implicit',
+      };
+      const { system } = buildExtractionPrompt(
+        testChunk,
+        implicitProfile,
+        emptyNeighborhood,
+        10,
+      );
+      expect(system).toContain('Temporal structure: implicit');
+      expect(system).toContain('No explicit temporal ordering');
     });
   });
 });

--- a/packages/core/src/ingestion/extraction-prompt.test.ts
+++ b/packages/core/src/ingestion/extraction-prompt.test.ts
@@ -337,7 +337,7 @@ describe('buildExtractionPrompt', () => {
         10,
       );
       expect(user).not.toContain(longValue);
-      expect(user).toContain('x'.repeat(200) + '...');
+      expect(user).toContain(`${'x'.repeat(200)}...`);
     });
 
     it('should omit occurred_at when not present in events', () => {

--- a/packages/core/src/ingestion/extraction-prompt.ts
+++ b/packages/core/src/ingestion/extraction-prompt.ts
@@ -14,9 +14,10 @@ export function buildExtractionPrompt(
   chunk: ParsedChunk,
   profile: DocumentProfile,
   neighborhood: NeighborhoodContext,
+  totalChunks: number,
 ): { system: string; user: string } {
   const system = buildSystemPrompt(profile);
-  const user = buildUserPrompt(chunk, neighborhood);
+  const user = buildUserPrompt(chunk, neighborhood, totalChunks);
   return { system, user };
 }
 
@@ -33,6 +34,9 @@ function buildSystemPrompt(profile: DocumentProfile): string {
     `Causal patterns to detect: ${profile.causal_patterns.join('; ')}`,
     '',
     `Extraction focus: ${profile.extraction_focus}`,
+    '',
+    `Temporal structure: ${profile.temporal_structure}`,
+    temporalGuidance(profile.temporal_structure),
     '',
     'Confidence calibration:',
     `- Explicit causation (stated directly): ${profile.confidence_calibration.explicit_causation}`,
@@ -58,6 +62,7 @@ function buildSystemPrompt(profile: DocumentProfile): string {
 function buildUserPrompt(
   chunk: ParsedChunk,
   neighborhood: NeighborhoodContext,
+  totalChunks: number,
 ): string {
   const sections: string[] = [];
 
@@ -71,7 +76,11 @@ function buildUserPrompt(
 
   if (neighborhood.recentEvents.length > 0) {
     const eventList = neighborhood.recentEvents
-      .map((e) => e.description)
+      .map((e) =>
+        e.occurred_at
+          ? `${e.description} (${e.occurred_at})`
+          : e.description,
+      )
       .join('; ');
     sections.push(`Recent events: ${eventList}`);
   }
@@ -90,6 +99,30 @@ function buildUserPrompt(
     sections.push(`Related concepts: ${conceptList}`);
   }
 
+  // Chunk metadata
+  const infoParts: string[] = [];
+  infoParts.push(`Chunk ${chunk.position + 1} of ${totalChunks}`);
+  if (chunk.metadata.speaker) {
+    infoParts.push(`Speaker: ${chunk.metadata.speaker}`);
+  }
+  if (chunk.metadata.section) {
+    infoParts.push(`Section: ${chunk.metadata.section}`);
+  }
+  if (chunk.metadata.turn_index != null) {
+    infoParts.push(`Turn: ${chunk.metadata.turn_index}`);
+  }
+  if (chunk.metadata.timestamp) {
+    infoParts.push(`Timestamp: ${chunk.metadata.timestamp}`);
+  }
+  if (chunk.metadata.extra) {
+    for (const [key, value] of Object.entries(chunk.metadata.extra)) {
+      if (value != null) {
+        infoParts.push(`${key}: ${String(value)}`);
+      }
+    }
+  }
+  sections.push(`Chunk info: ${infoParts.join(' | ')}`);
+
   // Build user prompt
   const parts: string[] = [];
 
@@ -104,6 +137,19 @@ function buildUserPrompt(
   parts.push(chunk.content);
 
   return parts.join('\n');
+}
+
+function temporalGuidance(
+  structure: DocumentProfile['temporal_structure'],
+): string {
+  switch (structure) {
+    case 'explicit_timestamps':
+      return 'Use timestamps for fact valid_from/valid_to dates.';
+    case 'session_ordered':
+      return 'Chunks are chronologically ordered. Infer relative timing from position.';
+    case 'implicit':
+      return 'No explicit temporal ordering. Extract temporal references from text.';
+  }
 }
 
 /**

--- a/packages/core/src/ingestion/extraction-prompt.ts
+++ b/packages/core/src/ingestion/extraction-prompt.ts
@@ -59,19 +59,22 @@ function buildSystemPrompt(profile: DocumentProfile): string {
   return lines.join('\n');
 }
 
+// Max chars per extra metadata value injected into the prompt
+const MAX_EXTRA_VALUE_LENGTH = 200;
+
 function buildUserPrompt(
   chunk: ParsedChunk,
   neighborhood: NeighborhoodContext,
   totalChunks: number,
 ): string {
-  const sections: string[] = [];
+  // Neighborhood context (only from graph data)
+  const neighborhoodSections: string[] = [];
 
-  // Neighborhood context
   if (neighborhood.knownEntities.length > 0) {
     const entityList = neighborhood.knownEntities
       .map((e) => `${e.name} (${e.type})`)
       .join(', ');
-    sections.push(`Known entities: ${entityList}`);
+    neighborhoodSections.push(`Known entities: ${entityList}`);
   }
 
   if (neighborhood.recentEvents.length > 0) {
@@ -80,21 +83,21 @@ function buildUserPrompt(
         e.occurred_at ? `${e.description} (${e.occurred_at})` : e.description,
       )
       .join('; ');
-    sections.push(`Recent events: ${eventList}`);
+    neighborhoodSections.push(`Recent events: ${eventList}`);
   }
 
   if (neighborhood.activeCausalChains.length > 0) {
     const chainList = neighborhood.activeCausalChains
       .map((c) => `${c.cause} → ${c.effect} (${c.confidence})`)
       .join('; ');
-    sections.push(`Active causal chains: ${chainList}`);
+    neighborhoodSections.push(`Active causal chains: ${chainList}`);
   }
 
   if (neighborhood.similarConcepts.length > 0) {
     const conceptList = neighborhood.similarConcepts
       .map((c) => c.name)
       .join(', ');
-    sections.push(`Related concepts: ${conceptList}`);
+    neighborhoodSections.push(`Related concepts: ${conceptList}`);
   }
 
   // Chunk metadata
@@ -115,26 +118,33 @@ function buildUserPrompt(
   if (chunk.metadata.extra) {
     for (const [key, value] of Object.entries(chunk.metadata.extra)) {
       if (value != null) {
-        infoParts.push(`${key}: ${String(value)}`);
+        const truncated = truncateValue(String(value), MAX_EXTRA_VALUE_LENGTH);
+        infoParts.push(`${key}: ${truncated}`);
       }
     }
   }
-  sections.push(`Chunk info: ${infoParts.join(' | ')}`);
 
   // Build user prompt
   const parts: string[] = [];
 
-  if (sections.length > 0) {
+  if (neighborhoodSections.length > 0) {
     parts.push('Context from existing graph:');
-    parts.push(...sections);
+    parts.push(...neighborhoodSections);
     parts.push('');
   }
 
+  parts.push(`Chunk info: ${infoParts.join(' | ')}`);
+  parts.push('');
   parts.push('Extract structured data from this text:');
   parts.push('');
   parts.push(chunk.content);
 
   return parts.join('\n');
+}
+
+function truncateValue(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}...`;
 }
 
 function temporalGuidance(

--- a/packages/core/src/ingestion/extraction-prompt.ts
+++ b/packages/core/src/ingestion/extraction-prompt.ts
@@ -77,9 +77,7 @@ function buildUserPrompt(
   if (neighborhood.recentEvents.length > 0) {
     const eventList = neighborhood.recentEvents
       .map((e) =>
-        e.occurred_at
-          ? `${e.description} (${e.occurred_at})`
-          : e.description,
+        e.occurred_at ? `${e.description} (${e.occurred_at})` : e.description,
       )
       .join('; ');
     sections.push(`Recent events: ${eventList}`);

--- a/packages/core/src/ingestion/index.ts
+++ b/packages/core/src/ingestion/index.ts
@@ -140,9 +140,7 @@ export async function ingest(
       extraction_calls: slowResult.extractedChunks + slowResult.skippedChunks,
       embedding_calls: 1,
       total_llm_calls:
-        profilerCalls +
-        slowResult.extractedChunks +
-        slowResult.skippedChunks,
+        profilerCalls + slowResult.extractedChunks + slowResult.skippedChunks,
     },
     timing: {
       parse_ms: parseMs,

--- a/packages/core/src/ingestion/index.ts
+++ b/packages/core/src/ingestion/index.ts
@@ -7,6 +7,7 @@ import {
   runPostProcess,
 } from './post-process.js';
 import { profileDocument } from './profiler.js';
+import { getDefaultProfile } from './profiles.js';
 import { runSlowPath } from './slow-path.js';
 import type {
   DeduplicationResult,
@@ -53,9 +54,14 @@ export async function ingest(
   if (input.profileOverride) {
     profile = input.profileOverride;
   } else {
-    const profileResult = await profileDocument(chunks, deps.llm);
-    profile = profileResult.profile;
-    profilerCalls = profileResult.cached ? 0 : 1;
+    const detectedFormat = chunks[0]?.metadata.source_format ?? 'auto';
+    if (detectedFormat === 'conversation') {
+      profile = getDefaultProfile('conversation');
+    } else {
+      const profileResult = await profileDocument(chunks, deps.llm);
+      profile = profileResult.profile;
+      profilerCalls = profileResult.cached ? 0 : 1;
+    }
   }
   const profileMs = Date.now() - profileStart;
 

--- a/packages/core/src/ingestion/index.ts
+++ b/packages/core/src/ingestion/index.ts
@@ -53,8 +53,9 @@ export async function ingest(
   if (input.profileOverride) {
     profile = input.profileOverride;
   } else {
-    profile = await profileDocument(chunks, deps.llm);
-    profilerCalls = 1;
+    const profileResult = await profileDocument(chunks, deps.llm);
+    profile = profileResult.profile;
+    profilerCalls = profileResult.cached ? 0 : 1;
   }
   const profileMs = Date.now() - profileStart;
 

--- a/packages/core/src/ingestion/index.ts
+++ b/packages/core/src/ingestion/index.ts
@@ -6,10 +6,11 @@ import {
   getQualityMetrics,
   runPostProcess,
 } from './post-process.js';
-import { getDefaultProfile } from './profiles.js';
+import { profileDocument } from './profiler.js';
 import { runSlowPath } from './slow-path.js';
 import type {
   DeduplicationResult,
+  DocumentProfile,
   IngestInput,
   IngestionDeps,
   IngestionReport,
@@ -47,9 +48,14 @@ export async function ingest(
 
   // --- Step 2: Profile ---
   const profileStart = Date.now();
-  const profile =
-    input.profileOverride ??
-    getDefaultProfile(chunks[0].metadata.source_format);
+  let profile: DocumentProfile;
+  let profilerCalls = 0;
+  if (input.profileOverride) {
+    profile = input.profileOverride;
+  } else {
+    profile = await profileDocument(chunks, deps.llm);
+    profilerCalls = 1;
+  }
   const profileMs = Date.now() - profileStart;
 
   // --- Step 3: Fast path ---
@@ -129,10 +135,13 @@ export async function ingest(
     deduplication,
     quality_warnings: allWarnings,
     cost: {
-      profiler_calls: 0, // Phase 1: no LLM profiler
+      profiler_calls: profilerCalls,
       extraction_calls: slowResult.extractedChunks + slowResult.skippedChunks,
       embedding_calls: 1,
-      total_llm_calls: slowResult.extractedChunks + slowResult.skippedChunks,
+      total_llm_calls:
+        profilerCalls +
+        slowResult.extractedChunks +
+        slowResult.skippedChunks,
     },
     timing: {
       parse_ms: parseMs,

--- a/packages/core/src/ingestion/ingest.test.ts
+++ b/packages/core/src/ingestion/ingest.test.ts
@@ -256,8 +256,11 @@ describe('ingest', () => {
 
   it('should return failed when parser throws', async () => {
     const deps = makeDeps();
-    // Invalid JSON that starts with [ but is malformed
-    const report = await ingest({ content: '[{invalid json}]' }, deps);
+    // Force conversation format on invalid JSON → parser throws
+    const report = await ingest(
+      { content: '[{invalid json}]', format: 'conversation' },
+      deps,
+    );
 
     expect(report.status).toBe('failed');
     expect(
@@ -311,8 +314,13 @@ describe('ingest', () => {
     const llm = {
       complete: vi
         .fn()
+        // First call: profiler (returns invalid profile → falls back to default)
+        .mockResolvedValueOnce(JSON.stringify({ bad: 'profile' }))
+        // Chunk 0 attempt 1: fail
         .mockRejectedValueOnce(new Error('LLM timeout'))
-        .mockRejectedValueOnce(new Error('LLM timeout')) // retry
+        // Chunk 0 attempt 2 (retry): fail → chunk skipped
+        .mockRejectedValueOnce(new Error('LLM timeout'))
+        // Remaining chunks: succeed
         .mockResolvedValue(JSON.stringify(validExtraction)),
     } as unknown as LLMProvider;
 
@@ -378,5 +386,75 @@ describe('ingest', () => {
 
     expect(report.status).toMatch(/^completed/);
     expect(report.chunks.total).toBe(5);
+  });
+
+  // --- Phase 2: Text + Structured + Profiler ---
+
+  it('should ingest plain text content', async () => {
+    const deps = makeDeps();
+    const text = 'First paragraph about Alice.\n\nSecond paragraph about Bob.';
+    const report = await ingest({ content: text, format: 'text' }, deps);
+
+    expect(report.status).toMatch(/^completed/);
+    expect(report.chunks.total).toBe(1); // small text fits in 1 chunk
+    expect(report.chunks.fast_path_written).toBe(1);
+  });
+
+  it('should auto-detect and ingest plain text', async () => {
+    const deps = makeDeps();
+    const text = 'This is a plain text document about technology and science.';
+    const report = await ingest({ content: text }, deps);
+
+    expect(report.status).toMatch(/^completed/);
+    expect(report.chunks.total).toBeGreaterThan(0);
+  });
+
+  it('should ingest structured JSON content', async () => {
+    const deps = makeDeps();
+    const data = JSON.stringify([
+      { id: 1, type: 'event', message: 'login' },
+      { id: 2, type: 'event', message: 'logout' },
+    ]);
+    const report = await ingest({ content: data, format: 'structured' }, deps);
+
+    expect(report.status).toMatch(/^completed/);
+    expect(report.chunks.total).toBe(2);
+    expect(report.chunks.fast_path_written).toBe(2);
+  });
+
+  it('should set profiler_calls=1 when no profileOverride', async () => {
+    const deps = makeDeps();
+    const report = await ingest({ content: makeFiveTurnConversation() }, deps);
+
+    expect(report.cost.profiler_calls).toBe(1);
+    expect(report.cost.total_llm_calls).toBe(
+      report.cost.profiler_calls + report.cost.extraction_calls,
+    );
+  });
+
+  it('should set profiler_calls=0 when profileOverride provided', async () => {
+    const deps = makeDeps();
+    const customProfile = {
+      document_type: 'technical',
+      domain: 'engineering',
+      entity_types_expected: ['component'],
+      relationship_types_expected: ['depends_on'],
+      causal_patterns: ['failure → outage'],
+      temporal_structure: 'explicit_timestamps' as const,
+      extraction_focus: 'Focus on components.',
+      confidence_calibration: {
+        explicit_causation: 1.0,
+        strong_implication: 0.9,
+        weak_inference: 0.7,
+      },
+    };
+
+    const report = await ingest(
+      { content: makeFiveTurnConversation(), profileOverride: customProfile },
+      deps,
+    );
+
+    expect(report.cost.profiler_calls).toBe(0);
+    expect(report.cost.total_llm_calls).toBe(report.cost.extraction_calls);
   });
 });

--- a/packages/core/src/ingestion/ingest.test.ts
+++ b/packages/core/src/ingestion/ingest.test.ts
@@ -2,6 +2,7 @@ import type { EmbeddingProvider, LLMProvider } from '@polyg-mcp/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { FalkorDBAdapter } from '../storage/falkordb.js';
 import { ingest } from './index.js';
+import { clearProfileCache } from './profiler.js';
 import type { ChunkExtraction, IngestionDeps } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -216,6 +217,7 @@ function makeFiveTurnConversation(): string {
 describe('ingest', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearProfileCache();
   });
 
   it('should complete full pipeline with 5-turn conversation', async () => {
@@ -456,5 +458,48 @@ describe('ingest', () => {
 
     expect(report.cost.profiler_calls).toBe(0);
     expect(report.cost.total_llm_calls).toBe(report.cost.extraction_calls);
+  });
+
+  it('should set profiler_calls=0 on cache hit for same content', async () => {
+    const content = makeFiveTurnConversation();
+
+    // LLM must return a valid DocumentProfile for the profiler call (first call)
+    // so it gets cached, then validExtraction for chunk extraction calls.
+    const validProfileJson = JSON.stringify({
+      document_type: 'conversation',
+      domain: 'general',
+      entity_types_expected: ['person'],
+      relationship_types_expected: ['knows'],
+      causal_patterns: [],
+      temporal_structure: 'explicit_timestamps',
+      extraction_focus: 'Focus on entities.',
+      confidence_calibration: {
+        explicit_causation: 1.0,
+        strong_implication: 0.85,
+        weak_inference: 0.6,
+      },
+    });
+
+    // First ingest — profiler calls LLM (cache miss), profile gets cached
+    const llm1 = {
+      complete: vi
+        .fn()
+        .mockResolvedValueOnce(validProfileJson) // profiler
+        .mockResolvedValue(JSON.stringify(validExtraction)), // chunk extraction
+    } as unknown as LLMProvider;
+    const deps1 = makeDeps({ llm: llm1 });
+    const first = await ingest({ content }, deps1);
+    expect(first.cost.profiler_calls).toBe(1);
+
+    // Second ingest with same content — profiler cache hit, no profiler LLM call
+    const llm2 = {
+      complete: vi
+        .fn()
+        .mockResolvedValue(JSON.stringify(validExtraction)), // only chunk extraction
+    } as unknown as LLMProvider;
+    const deps2 = makeDeps({ llm: llm2 });
+    const second = await ingest({ content }, deps2);
+    expect(second.cost.profiler_calls).toBe(0);
+    expect(second.cost.total_llm_calls).toBe(second.cost.extraction_calls);
   });
 });

--- a/packages/core/src/ingestion/ingest.test.ts
+++ b/packages/core/src/ingestion/ingest.test.ts
@@ -468,6 +468,47 @@ describe('ingest', () => {
     expect(report.cost.total_llm_calls).toBe(report.cost.extraction_calls);
   });
 
+  it('should normalize non-canonical entity types through the pipeline', async () => {
+    // LLM returns non-canonical types — normalization should map them
+    const nonCanonicalExtraction: ChunkExtraction = {
+      entities: [
+        { name: 'Alice', entity_type: 'Individual' },   // → person
+        { name: 'Acme', entity_type: 'Company' },       // → organization
+        { name: 'Paris', entity_type: 'City' },          // → location
+      ],
+      relationships: [
+        { source: 'Alice', target: 'Acme', relationship_type: 'works_at' },
+      ],
+      causal_links: [],
+      facts: [],
+    };
+
+    const db = createMockDb();
+    const deps: IngestionDeps = {
+      db,
+      embeddings: createMockEmbeddings(),
+      llm: {
+        complete: vi.fn().mockResolvedValue(JSON.stringify(nonCanonicalExtraction)),
+      } as unknown as LLMProvider,
+    };
+
+    await ingest({ content: makeFiveTurnConversation() }, deps);
+
+    // Verify entities were created with canonical types via createNode calls
+    const createNodeCalls = vi.mocked(db.createNode).mock.calls;
+    const entityCalls = createNodeCalls.filter(([label]) => label === 'E_Entity');
+
+    // Should have created entities with normalized types
+    const entityTypes = entityCalls.map(([, props]) => props.entity_type);
+    expect(entityTypes).toContain('person');
+    expect(entityTypes).toContain('organization');
+    expect(entityTypes).toContain('location');
+    // Non-canonical types should NOT appear
+    expect(entityTypes).not.toContain('Individual');
+    expect(entityTypes).not.toContain('Company');
+    expect(entityTypes).not.toContain('City');
+  });
+
   it('should set profiler_calls=0 on cache hit for same text content', async () => {
     // Use text format (not conversation) so profiler is actually invoked
     const content = 'A document about technology and science. '.repeat(20);

--- a/packages/core/src/ingestion/ingest.test.ts
+++ b/packages/core/src/ingestion/ingest.test.ts
@@ -493,9 +493,7 @@ describe('ingest', () => {
 
     // Second ingest with same content — profiler cache hit, no profiler LLM call
     const llm2 = {
-      complete: vi
-        .fn()
-        .mockResolvedValue(JSON.stringify(validExtraction)), // only chunk extraction
+      complete: vi.fn().mockResolvedValue(JSON.stringify(validExtraction)), // only chunk extraction
     } as unknown as LLMProvider;
     const deps2 = makeDeps({ llm: llm2 });
     const second = await ingest({ content }, deps2);

--- a/packages/core/src/ingestion/ingest.test.ts
+++ b/packages/core/src/ingestion/ingest.test.ts
@@ -313,11 +313,10 @@ describe('ingest', () => {
   });
 
   it('should bubble slow path warnings to quality_warnings', async () => {
+    // Conversation format skips profiler, so all LLM calls are extraction
     const llm = {
       complete: vi
         .fn()
-        // First call: profiler (returns invalid profile → falls back to default)
-        .mockResolvedValueOnce(JSON.stringify({ bad: 'profile' }))
         // Chunk 0 attempt 1: fail
         .mockRejectedValueOnce(new Error('LLM timeout'))
         // Chunk 0 attempt 2 (retry): fail → chunk skipped
@@ -424,9 +423,18 @@ describe('ingest', () => {
     expect(report.chunks.fast_path_written).toBe(2);
   });
 
-  it('should set profiler_calls=1 when no profileOverride', async () => {
+  it('should set profiler_calls=0 for conversations (profiler skipped)', async () => {
     const deps = makeDeps();
     const report = await ingest({ content: makeFiveTurnConversation() }, deps);
+
+    expect(report.cost.profiler_calls).toBe(0);
+    expect(report.cost.total_llm_calls).toBe(report.cost.extraction_calls);
+  });
+
+  it('should set profiler_calls=1 for text content', async () => {
+    const deps = makeDeps();
+    const text = 'A long document about technology and science. '.repeat(20);
+    const report = await ingest({ content: text, format: 'text' }, deps);
 
     expect(report.cost.profiler_calls).toBe(1);
     expect(report.cost.total_llm_calls).toBe(
@@ -460,18 +468,17 @@ describe('ingest', () => {
     expect(report.cost.total_llm_calls).toBe(report.cost.extraction_calls);
   });
 
-  it('should set profiler_calls=0 on cache hit for same content', async () => {
-    const content = makeFiveTurnConversation();
+  it('should set profiler_calls=0 on cache hit for same text content', async () => {
+    // Use text format (not conversation) so profiler is actually invoked
+    const content = 'A document about technology and science. '.repeat(20);
 
-    // LLM must return a valid DocumentProfile for the profiler call (first call)
-    // so it gets cached, then validExtraction for chunk extraction calls.
     const validProfileJson = JSON.stringify({
-      document_type: 'conversation',
+      document_type: 'text_document',
       domain: 'general',
       entity_types_expected: ['person'],
       relationship_types_expected: ['knows'],
       causal_patterns: [],
-      temporal_structure: 'explicit_timestamps',
+      temporal_structure: 'implicit',
       extraction_focus: 'Focus on entities.',
       confidence_calibration: {
         explicit_causation: 1.0,
@@ -488,7 +495,7 @@ describe('ingest', () => {
         .mockResolvedValue(JSON.stringify(validExtraction)), // chunk extraction
     } as unknown as LLMProvider;
     const deps1 = makeDeps({ llm: llm1 });
-    const first = await ingest({ content }, deps1);
+    const first = await ingest({ content, format: 'text' }, deps1);
     expect(first.cost.profiler_calls).toBe(1);
 
     // Second ingest with same content — profiler cache hit, no profiler LLM call
@@ -496,7 +503,7 @@ describe('ingest', () => {
       complete: vi.fn().mockResolvedValue(JSON.stringify(validExtraction)), // only chunk extraction
     } as unknown as LLMProvider;
     const deps2 = makeDeps({ llm: llm2 });
-    const second = await ingest({ content }, deps2);
+    const second = await ingest({ content, format: 'text' }, deps2);
     expect(second.cost.profiler_calls).toBe(0);
     expect(second.cost.total_llm_calls).toBe(second.cost.extraction_calls);
   });

--- a/packages/core/src/ingestion/ingest.test.ts
+++ b/packages/core/src/ingestion/ingest.test.ts
@@ -472,9 +472,9 @@ describe('ingest', () => {
     // LLM returns non-canonical types — normalization should map them
     const nonCanonicalExtraction: ChunkExtraction = {
       entities: [
-        { name: 'Alice', entity_type: 'Individual' },   // → person
-        { name: 'Acme', entity_type: 'Company' },       // → organization
-        { name: 'Paris', entity_type: 'City' },          // → location
+        { name: 'Alice', entity_type: 'Individual' }, // → person
+        { name: 'Acme', entity_type: 'Company' }, // → organization
+        { name: 'Paris', entity_type: 'City' }, // → location
       ],
       relationships: [
         { source: 'Alice', target: 'Acme', relationship_type: 'works_at' },
@@ -488,7 +488,9 @@ describe('ingest', () => {
       db,
       embeddings: createMockEmbeddings(),
       llm: {
-        complete: vi.fn().mockResolvedValue(JSON.stringify(nonCanonicalExtraction)),
+        complete: vi
+          .fn()
+          .mockResolvedValue(JSON.stringify(nonCanonicalExtraction)),
       } as unknown as LLMProvider,
     };
 
@@ -496,7 +498,9 @@ describe('ingest', () => {
 
     // Verify entities were created with canonical types via createNode calls
     const createNodeCalls = vi.mocked(db.createNode).mock.calls;
-    const entityCalls = createNodeCalls.filter(([label]) => label === 'E_Entity');
+    const entityCalls = createNodeCalls.filter(
+      ([label]) => label === 'E_Entity',
+    );
 
     // Should have created entities with normalized types
     const entityTypes = entityCalls.map(([, props]) => props.entity_type);

--- a/packages/core/src/ingestion/normalize.test.ts
+++ b/packages/core/src/ingestion/normalize.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeEntityType, normalizeExtraction } from './normalize.js';
+import type { ChunkExtraction } from './types.js';
+
+describe('normalizeEntityType', () => {
+  it('should map person synonyms', () => {
+    expect(normalizeEntityType('individual')).toBe('person');
+    expect(normalizeEntityType('human')).toBe('person');
+    expect(normalizeEntityType('character')).toBe('person');
+    expect(normalizeEntityType('participant')).toBe('person');
+    expect(normalizeEntityType('speaker')).toBe('person');
+  });
+
+  it('should map organization synonyms', () => {
+    expect(normalizeEntityType('company')).toBe('organization');
+    expect(normalizeEntityType('firm')).toBe('organization');
+    expect(normalizeEntityType('corporation')).toBe('organization');
+    expect(normalizeEntityType('institution')).toBe('organization');
+    expect(normalizeEntityType('agency')).toBe('organization');
+  });
+
+  it('should map location synonyms', () => {
+    expect(normalizeEntityType('place')).toBe('location');
+    expect(normalizeEntityType('city')).toBe('location');
+    expect(normalizeEntityType('country')).toBe('location');
+    expect(normalizeEntityType('region')).toBe('location');
+    expect(normalizeEntityType('venue')).toBe('location');
+  });
+
+  it('should map event synonyms', () => {
+    expect(normalizeEntityType('incident')).toBe('event');
+    expect(normalizeEntityType('occurrence')).toBe('event');
+    expect(normalizeEntityType('activity')).toBe('event');
+  });
+
+  it('should map concept synonyms', () => {
+    expect(normalizeEntityType('idea')).toBe('concept');
+    expect(normalizeEntityType('theme')).toBe('concept');
+    expect(normalizeEntityType('subject')).toBe('concept');
+  });
+
+  it('should be case insensitive', () => {
+    expect(normalizeEntityType('COMPANY')).toBe('organization');
+    expect(normalizeEntityType('Human')).toBe('person');
+    expect(normalizeEntityType('PLACE')).toBe('location');
+  });
+
+  it('should trim whitespace', () => {
+    expect(normalizeEntityType('  company  ')).toBe('organization');
+    expect(normalizeEntityType(' person ')).toBe('person');
+  });
+
+  it('should pass through unknown types', () => {
+    expect(normalizeEntityType('product')).toBe('product');
+    expect(normalizeEntityType('metric')).toBe('metric');
+    expect(normalizeEntityType('custom_type')).toBe('custom_type');
+  });
+
+  it('should pass through already-canonical types', () => {
+    expect(normalizeEntityType('person')).toBe('person');
+    expect(normalizeEntityType('organization')).toBe('organization');
+    expect(normalizeEntityType('location')).toBe('location');
+    expect(normalizeEntityType('event')).toBe('event');
+    expect(normalizeEntityType('concept')).toBe('concept');
+  });
+});
+
+describe('normalizeExtraction', () => {
+  it('should normalize entity types in extraction', () => {
+    const extraction: ChunkExtraction = {
+      entities: [
+        { name: 'Alice', entity_type: 'Individual' },
+        { name: 'Acme', entity_type: 'Company' },
+        { name: 'Paris', entity_type: 'City' },
+      ],
+      relationships: [
+        { source: 'Alice', target: 'Acme', relationship_type: 'works_at' },
+      ],
+      causal_links: [],
+      facts: [],
+    };
+
+    const result = normalizeExtraction(extraction);
+
+    expect(result.entities[0].entity_type).toBe('person');
+    expect(result.entities[1].entity_type).toBe('organization');
+    expect(result.entities[2].entity_type).toBe('location');
+    // Should return the same object (mutated in place)
+    expect(result).toBe(extraction);
+  });
+
+  it('should handle empty extraction', () => {
+    const extraction: ChunkExtraction = {
+      entities: [],
+      relationships: [],
+      causal_links: [],
+      facts: [],
+    };
+
+    const result = normalizeExtraction(extraction);
+
+    expect(result.entities).toEqual([]);
+    expect(result).toBe(extraction);
+  });
+
+  it('should preserve unknown entity types', () => {
+    const extraction: ChunkExtraction = {
+      entities: [{ name: 'Widget', entity_type: 'product' }],
+      relationships: [],
+      causal_links: [],
+      facts: [],
+    };
+
+    normalizeExtraction(extraction);
+
+    expect(extraction.entities[0].entity_type).toBe('product');
+  });
+});

--- a/packages/core/src/ingestion/normalize.test.ts
+++ b/packages/core/src/ingestion/normalize.test.ts
@@ -89,8 +89,9 @@ describe('normalizeExtraction', () => {
     expect(result.entities[0].entity_type).toBe('person');
     expect(result.entities[1].entity_type).toBe('organization');
     expect(result.entities[2].entity_type).toBe('location');
-    // Should return the same object (mutated in place)
-    expect(result).toBe(extraction);
+    // Should return a new object, not mutate the original
+    expect(result).not.toBe(extraction);
+    expect(extraction.entities[0].entity_type).toBe('Individual');
   });
 
   it('should handle empty extraction', () => {
@@ -104,7 +105,8 @@ describe('normalizeExtraction', () => {
     const result = normalizeExtraction(extraction);
 
     expect(result.entities).toEqual([]);
-    expect(result).toBe(extraction);
+    // Still a new object even when empty
+    expect(result).not.toBe(extraction);
   });
 
   it('should preserve unknown entity types', () => {
@@ -115,9 +117,28 @@ describe('normalizeExtraction', () => {
       facts: [],
     };
 
-    normalizeExtraction(extraction);
+    const result = normalizeExtraction(extraction);
 
+    expect(result.entities[0].entity_type).toBe('product');
+    // Original unchanged
     expect(extraction.entities[0].entity_type).toBe('product');
+  });
+
+  it('should share non-entity fields by reference', () => {
+    const relationships = [
+      { source: 'A', target: 'B', relationship_type: 'knows' },
+    ];
+    const extraction: ChunkExtraction = {
+      entities: [{ name: 'A', entity_type: 'Individual' }],
+      relationships,
+      causal_links: [],
+      facts: [],
+    };
+
+    const result = normalizeExtraction(extraction);
+
+    // Shallow copy shares non-entity arrays
+    expect(result.relationships).toBe(relationships);
   });
 });
 

--- a/packages/core/src/ingestion/normalize.test.ts
+++ b/packages/core/src/ingestion/normalize.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeEntityType, normalizeExtraction } from './normalize.js';
+import {
+  normalizeEntityType,
+  normalizeExtraction,
+  stripJsonFences,
+} from './normalize.js';
 import type { ChunkExtraction } from './types.js';
 
 describe('normalizeEntityType', () => {
@@ -114,5 +118,39 @@ describe('normalizeExtraction', () => {
     normalizeExtraction(extraction);
 
     expect(extraction.entities[0].entity_type).toBe('product');
+  });
+});
+
+describe('stripJsonFences', () => {
+  it('should return bare JSON unchanged', () => {
+    const json = '{"key": "value"}';
+    expect(stripJsonFences(json)).toBe('{"key": "value"}');
+  });
+
+  it('should strip ```json fences', () => {
+    const fenced = '```json\n{"key": "value"}\n```';
+    expect(stripJsonFences(fenced)).toBe('{"key": "value"}');
+  });
+
+  it('should strip bare ``` fences', () => {
+    const fenced = '```\n{"key": "value"}\n```';
+    expect(stripJsonFences(fenced)).toBe('{"key": "value"}');
+  });
+
+  it('should handle leading/trailing whitespace', () => {
+    const fenced = '  ```json\n{"key": "value"}\n```  ';
+    expect(stripJsonFences(fenced)).toBe('{"key": "value"}');
+  });
+
+  it('should handle multiline JSON inside fences', () => {
+    const fenced = '```json\n{\n  "entities": [],\n  "facts": []\n}\n```';
+    expect(stripJsonFences(fenced)).toBe(
+      '{\n  "entities": [],\n  "facts": []\n}',
+    );
+  });
+
+  it('should not strip fences from mid-content backticks', () => {
+    const json = '{"code": "use ```bash``` for shell"}';
+    expect(stripJsonFences(json)).toBe(json);
   });
 });

--- a/packages/core/src/ingestion/normalize.ts
+++ b/packages/core/src/ingestion/normalize.ts
@@ -41,15 +41,18 @@ export function normalizeEntityType(type: string): string {
 
 /**
  * Normalize all entity types in a chunk extraction result.
- * Mutates in place and returns the same object.
+ * Returns a shallow copy — the original extraction is not mutated.
  */
 export function normalizeExtraction(
   extraction: ChunkExtraction,
 ): ChunkExtraction {
-  for (const entity of extraction.entities) {
-    entity.entity_type = normalizeEntityType(entity.entity_type);
-  }
-  return extraction;
+  return {
+    ...extraction,
+    entities: extraction.entities.map((e) => ({
+      ...e,
+      entity_type: normalizeEntityType(e.entity_type),
+    })),
+  };
 }
 
 /**

--- a/packages/core/src/ingestion/normalize.ts
+++ b/packages/core/src/ingestion/normalize.ts
@@ -1,0 +1,53 @@
+// Entity type normalization — maps LLM-generated synonyms to canonical types
+import type { ChunkExtraction } from './types.js';
+
+const ENTITY_TYPE_MAP: Record<string, string> = {
+  // person
+  individual: 'person',
+  human: 'person',
+  character: 'person',
+  participant: 'person',
+  speaker: 'person',
+  // organization
+  company: 'organization',
+  firm: 'organization',
+  corporation: 'organization',
+  institution: 'organization',
+  agency: 'organization',
+  // location
+  place: 'location',
+  city: 'location',
+  country: 'location',
+  region: 'location',
+  venue: 'location',
+  // event
+  incident: 'event',
+  occurrence: 'event',
+  activity: 'event',
+  // concept
+  idea: 'concept',
+  theme: 'concept',
+  subject: 'concept',
+};
+
+/**
+ * Normalize an entity type string to its canonical form.
+ * Lowercases, trims, and maps known synonyms. Unknown types pass through.
+ */
+export function normalizeEntityType(type: string): string {
+  const key = type.toLowerCase().trim();
+  return ENTITY_TYPE_MAP[key] ?? key;
+}
+
+/**
+ * Normalize all entity types in a chunk extraction result.
+ * Mutates in place and returns the same object.
+ */
+export function normalizeExtraction(
+  extraction: ChunkExtraction,
+): ChunkExtraction {
+  for (const entity of extraction.entities) {
+    entity.entity_type = normalizeEntityType(entity.entity_type);
+  }
+  return extraction;
+}

--- a/packages/core/src/ingestion/normalize.ts
+++ b/packages/core/src/ingestion/normalize.ts
@@ -51,3 +51,17 @@ export function normalizeExtraction(
   }
   return extraction;
 }
+
+/**
+ * Strip markdown JSON code fences from LLM output before parsing.
+ * Handles ```json ... ```, ``` ... ```, and bare JSON.
+ */
+export function stripJsonFences(raw: string): string {
+  const trimmed = raw.trim();
+  // Match ```json ... ``` or ``` ... ```
+  const fenceMatch = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/);
+  if (fenceMatch) {
+    return fenceMatch[1].trim();
+  }
+  return trimmed;
+}

--- a/packages/core/src/ingestion/parser/index.ts
+++ b/packages/core/src/ingestion/parser/index.ts
@@ -2,6 +2,8 @@
 import type { InputFormat, ParsedChunk } from '../types.js';
 import { parseConversation } from './conversation.js';
 import { detectFormat } from './detect.js';
+import { parseStructured } from './structured.js';
+import { parseText } from './text.js';
 
 /**
  * Parse raw content into chunks.
@@ -17,13 +19,9 @@ export function parse(content: string, format?: InputFormat): ParsedChunk[] {
     case 'conversation':
       return parseConversation(content);
     case 'text':
-      throw new Error(
-        'Not implemented: text parser (Phase 2). Use format "conversation" or provide structured JSON.',
-      );
+      return parseText(content);
     case 'structured':
-      throw new Error(
-        'Not implemented: structured parser (Phase 2). Use format "conversation" or provide plain text.',
-      );
+      return parseStructured(content);
     default:
       throw new Error(`Unknown format: ${resolved as string}`);
   }
@@ -31,3 +29,5 @@ export function parse(content: string, format?: InputFormat): ParsedChunk[] {
 
 export { parseConversation } from './conversation.js';
 export { detectFormat } from './detect.js';
+export { parseStructured } from './structured.js';
+export { parseText } from './text.js';

--- a/packages/core/src/ingestion/parser/parser.test.ts
+++ b/packages/core/src/ingestion/parser/parser.test.ts
@@ -23,22 +23,37 @@ describe('parse (router)', () => {
     expect(chunks).toHaveLength(2);
   });
 
-  it('should throw for text format (Phase 2 stub)', () => {
-    expect(() => parse('plain text content', 'text')).toThrow(
-      'Not implemented: text parser',
-    );
+  it('should parse plain text with explicit format', () => {
+    const chunks = parse('plain text content', 'text');
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.source_format).toBe('text');
+    expect(chunks[0].content).toBe('plain text content');
   });
 
-  it('should throw for structured format (Phase 2 stub)', () => {
+  it('should parse structured JSON with explicit format', () => {
     const structured = JSON.stringify([{ id: 1, value: 'data' }]);
-    expect(() => parse(structured, 'structured')).toThrow(
-      'Not implemented: structured parser',
-    );
+    const chunks = parse(structured, 'structured');
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.source_format).toBe('structured');
   });
 
-  it('should auto-detect plain text and throw Phase 2 stub', () => {
-    expect(() => parse('Just some plain text.')).toThrow(
-      'Not implemented: text parser',
-    );
+  it('should auto-detect plain text', () => {
+    const chunks = parse('Just some plain text.');
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.source_format).toBe('text');
+  });
+
+  it('should auto-detect structured JSON (non-conversation array)', () => {
+    const data = JSON.stringify([{ id: 1, value: 'test' }]);
+    const chunks = parse(data);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.source_format).toBe('structured');
+  });
+
+  it('should auto-detect structured JSON (single object)', () => {
+    const data = JSON.stringify({ name: 'config', version: 2 });
+    const chunks = parse(data);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].metadata.source_format).toBe('structured');
   });
 });

--- a/packages/core/src/ingestion/parser/structured.test.ts
+++ b/packages/core/src/ingestion/parser/structured.test.ts
@@ -41,15 +41,26 @@ describe('parseStructured', () => {
     }
   });
 
-  it('should preserve record fields in metadata', () => {
-    const json = JSON.stringify({ id: 1, name: 'Alice', score: 95 });
-    const chunks = parseStructured(json);
-
-    expect(chunks[0].metadata).toMatchObject({
-      source_format: 'structured',
-      name: 'Alice',
+  it('should route standard fields to metadata and non-standard to extra', () => {
+    const json = JSON.stringify({
+      timestamp: '2024-01-01T00:00:00Z',
+      speaker: 'Alice',
+      id: 1,
       score: 95,
     });
+    const chunks = parseStructured(json);
+
+    expect(chunks[0].metadata.source_format).toBe('structured');
+    expect(chunks[0].metadata.timestamp).toBe('2024-01-01T00:00:00Z');
+    expect(chunks[0].metadata.speaker).toBe('Alice');
+    expect(chunks[0].metadata.extra).toEqual({ id: 1, score: 95 });
+  });
+
+  it('should omit extra when no non-standard fields exist', () => {
+    const json = JSON.stringify({ timestamp: '2024-01-01T00:00:00Z' });
+    const chunks = parseStructured(json);
+
+    expect(chunks[0].metadata.extra).toBeUndefined();
   });
 
   it('should skip nested objects and arrays in metadata', () => {
@@ -61,16 +72,9 @@ describe('parseStructured', () => {
     });
     const chunks = parseStructured(json);
 
-    expect(chunks[0].metadata).toMatchObject({
-      source_format: 'structured',
-      name: 'test',
-    });
-    expect(
-      (chunks[0].metadata as unknown as Record<string, unknown>).nested,
-    ).toBeUndefined();
-    expect(
-      (chunks[0].metadata as unknown as Record<string, unknown>).tags,
-    ).toBeUndefined();
+    expect(chunks[0].metadata.extra).toEqual({ id: 1, name: 'test' });
+    expect(chunks[0].metadata.extra?.nested).toBeUndefined();
+    expect(chunks[0].metadata.extra?.tags).toBeUndefined();
   });
 
   it('should not let record override source_format', () => {
@@ -101,8 +105,8 @@ describe('parseStructured', () => {
     const chunks = parseStructured(JSON.stringify(logs));
 
     expect(chunks).toHaveLength(2);
-    expect(chunks[0].metadata).toMatchObject({
-      timestamp: '2024-01-01T00:00:00Z',
+    expect(chunks[0].metadata.timestamp).toBe('2024-01-01T00:00:00Z');
+    expect(chunks[0].metadata.extra).toEqual({
       level: 'INFO',
       message: 'started',
     });

--- a/packages/core/src/ingestion/parser/structured.test.ts
+++ b/packages/core/src/ingestion/parser/structured.test.ts
@@ -35,9 +35,7 @@ describe('parseStructured', () => {
 
     expect(chunks).toHaveLength(3);
     for (let i = 0; i < 3; i++) {
-      expect(chunks[i].chunk_id).toBe(
-        `chunk_${i.toString().padStart(3, '0')}`,
-      );
+      expect(chunks[i].chunk_id).toBe(`chunk_${i.toString().padStart(3, '0')}`);
       expect(chunks[i].position).toBe(i);
       expect(chunks[i].metadata.source_format).toBe('structured');
     }
@@ -67,8 +65,12 @@ describe('parseStructured', () => {
       source_format: 'structured',
       name: 'test',
     });
-    expect((chunks[0].metadata as unknown as Record<string, unknown>).nested).toBeUndefined();
-    expect((chunks[0].metadata as unknown as Record<string, unknown>).tags).toBeUndefined();
+    expect(
+      (chunks[0].metadata as unknown as Record<string, unknown>).nested,
+    ).toBeUndefined();
+    expect(
+      (chunks[0].metadata as unknown as Record<string, unknown>).tags,
+    ).toBeUndefined();
   });
 
   it('should not let record override source_format', () => {

--- a/packages/core/src/ingestion/parser/structured.test.ts
+++ b/packages/core/src/ingestion/parser/structured.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { parseStructured } from './structured.js';
+
+describe('parseStructured', () => {
+  it('should throw for invalid JSON', () => {
+    expect(() => parseStructured('not json')).toThrow('Invalid JSON');
+  });
+
+  it('should return empty array for empty JSON array', () => {
+    expect(parseStructured('[]')).toEqual([]);
+  });
+
+  it('should parse a single object', () => {
+    const json = JSON.stringify({ id: 1, name: 'test', value: 42 });
+    const chunks = parseStructured(json);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].chunk_id).toBe('chunk_000');
+    expect(chunks[0].position).toBe(0);
+    expect(chunks[0].metadata.source_format).toBe('structured');
+    expect(JSON.parse(chunks[0].content)).toEqual({
+      id: 1,
+      name: 'test',
+      value: 42,
+    });
+  });
+
+  it('should parse an array of objects', () => {
+    const data = [
+      { id: 1, type: 'event', message: 'login' },
+      { id: 2, type: 'event', message: 'logout' },
+      { id: 3, type: 'event', message: 'error' },
+    ];
+    const chunks = parseStructured(JSON.stringify(data));
+
+    expect(chunks).toHaveLength(3);
+    for (let i = 0; i < 3; i++) {
+      expect(chunks[i].chunk_id).toBe(
+        `chunk_${i.toString().padStart(3, '0')}`,
+      );
+      expect(chunks[i].position).toBe(i);
+      expect(chunks[i].metadata.source_format).toBe('structured');
+    }
+  });
+
+  it('should preserve record fields in metadata', () => {
+    const json = JSON.stringify({ id: 1, name: 'Alice', score: 95 });
+    const chunks = parseStructured(json);
+
+    expect(chunks[0].metadata).toMatchObject({
+      source_format: 'structured',
+      name: 'Alice',
+      score: 95,
+    });
+  });
+
+  it('should skip nested objects and arrays in metadata', () => {
+    const json = JSON.stringify({
+      id: 1,
+      name: 'test',
+      nested: { a: 1 },
+      tags: ['foo'],
+    });
+    const chunks = parseStructured(json);
+
+    expect(chunks[0].metadata).toMatchObject({
+      source_format: 'structured',
+      name: 'test',
+    });
+    expect((chunks[0].metadata as unknown as Record<string, unknown>).nested).toBeUndefined();
+    expect((chunks[0].metadata as unknown as Record<string, unknown>).tags).toBeUndefined();
+  });
+
+  it('should not let record override source_format', () => {
+    const json = JSON.stringify({ source_format: 'hacked', name: 'test' });
+    const chunks = parseStructured(json);
+    expect(chunks[0].metadata.source_format).toBe('structured');
+  });
+
+  it('should skip primitive array entries', () => {
+    const json = JSON.stringify([{ id: 1 }, 'string', 42, null, { id: 2 }]);
+    const chunks = parseStructured(json);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].position).toBe(0);
+    expect(chunks[1].position).toBe(1);
+  });
+
+  it('should pretty-print JSON in chunk content', () => {
+    const json = JSON.stringify({ a: 1, b: 2 });
+    const chunks = parseStructured(json);
+    expect(chunks[0].content).toBe('{\n  "a": 1,\n  "b": 2\n}');
+  });
+
+  it('should handle log-style data', () => {
+    const logs = [
+      { timestamp: '2024-01-01T00:00:00Z', level: 'INFO', message: 'started' },
+      { timestamp: '2024-01-01T00:01:00Z', level: 'ERROR', message: 'failed' },
+    ];
+    const chunks = parseStructured(JSON.stringify(logs));
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].metadata).toMatchObject({
+      timestamp: '2024-01-01T00:00:00Z',
+      level: 'INFO',
+      message: 'started',
+    });
+  });
+});

--- a/packages/core/src/ingestion/parser/structured.test.ts
+++ b/packages/core/src/ingestion/parser/structured.test.ts
@@ -77,6 +77,26 @@ describe('parseStructured', () => {
     expect(chunks[0].metadata.extra?.tags).toBeUndefined();
   });
 
+  it('should coerce booleans to strings in extra metadata', () => {
+    const json = JSON.stringify({ active: true, enabled: false, name: 'test' });
+    const chunks = parseStructured(json);
+
+    expect(chunks[0].metadata.extra).toEqual({
+      active: 'true',
+      enabled: 'false',
+      name: 'test',
+    });
+  });
+
+  it('should truncate oversized record content', () => {
+    const largeRecord = { data: 'x'.repeat(10000) };
+    const chunks = parseStructured(JSON.stringify(largeRecord));
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].content.length).toBeLessThan(10000);
+    expect(chunks[0].content).toContain('... [truncated]');
+  });
+
   it('should not let record override source_format', () => {
     const json = JSON.stringify({ source_format: 'hacked', name: 'test' });
     const chunks = parseStructured(json);

--- a/packages/core/src/ingestion/parser/structured.ts
+++ b/packages/core/src/ingestion/parser/structured.ts
@@ -1,8 +1,10 @@
 // Structured JSON parser — each record becomes one chunk
 import type { ChunkMetadata, ParsedChunk } from '../types.js';
 
+// Max chars per structured chunk content (prevents DoS via large records)
+const MAX_RECORD_CHARS = 8000;
+
 const STANDARD_KEYS = new Set([
-  'source_format',
   'timestamp',
   'speaker',
   'section',
@@ -50,9 +52,14 @@ export function parseStructured(content: string): ParsedChunk[] {
       metadata.extra = extra;
     }
 
+    let content = JSON.stringify(record, null, 2);
+    if (content.length > MAX_RECORD_CHARS) {
+      content = `${content.slice(0, MAX_RECORD_CHARS)}\n... [truncated]`;
+    }
+
     chunks.push({
       chunk_id: `chunk_${position.toString().padStart(3, '0')}`,
-      content: JSON.stringify(record, null, 2),
+      content,
       position,
       metadata,
     });
@@ -76,15 +83,16 @@ function splitMetadata(record: Record<string, unknown>): {
     // Skip keys that conflict with ChunkMetadata fields
     if (key === 'source_format') continue;
 
-    if (typeof value !== 'string' && typeof value !== 'number') {
-      // Skip booleans, objects, arrays — keep metadata simple
+    if (typeof value === 'object' || Array.isArray(value) || value === null) {
+      // Skip objects, arrays, null — keep metadata flat
       continue;
     }
 
     if (STANDARD_KEYS.has(key)) {
-      standard[key] = value;
+      standard[key] = value as string | number;
     } else {
-      extra[key] = value;
+      // Coerce booleans to strings for extra metadata
+      extra[key] = typeof value === 'boolean' ? String(value) : value;
     }
   }
 

--- a/packages/core/src/ingestion/parser/structured.ts
+++ b/packages/core/src/ingestion/parser/structured.ts
@@ -1,0 +1,70 @@
+// Structured JSON parser — each record becomes one chunk
+import type { ParsedChunk } from '../types.js';
+
+/**
+ * Parse structured JSON into chunks.
+ *
+ * Accepts a JSON array of objects or a single object.
+ * Each record becomes one chunk with JSON-stringified content.
+ */
+export function parseStructured(content: string): ParsedChunk[] {
+  let data: unknown;
+  try {
+    data = JSON.parse(content);
+  } catch {
+    throw new Error('Invalid JSON: content is not valid JSON');
+  }
+
+  // Normalize: single object → array
+  const records = Array.isArray(data) ? data : [data];
+
+  if (records.length === 0) {
+    return [];
+  }
+
+  const chunks: ParsedChunk[] = [];
+
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i];
+    if (typeof record !== 'object' || record === null) {
+      continue; // skip primitives
+    }
+
+    const position = chunks.length;
+    chunks.push({
+      chunk_id: `chunk_${position.toString().padStart(3, '0')}`,
+      content: JSON.stringify(record, null, 2),
+      position,
+      metadata: {
+        source_format: 'structured',
+        ...flattenMetadata(record as Record<string, unknown>),
+      },
+    });
+  }
+
+  return chunks;
+}
+
+/**
+ * Extract flat string/number/boolean fields from a record for metadata.
+ * Skips nested objects and arrays to keep metadata flat.
+ */
+function flattenMetadata(
+  record: Record<string, unknown>,
+): Record<string, string | number | undefined> {
+  const result: Record<string, string | number | undefined> = {};
+
+  for (const [key, value] of Object.entries(record)) {
+    // Skip keys that conflict with ChunkMetadata fields
+    if (key === 'source_format') continue;
+
+    if (typeof value === 'string') {
+      result[key] = value;
+    } else if (typeof value === 'number') {
+      result[key] = value;
+    }
+    // Skip booleans, objects, arrays — keep metadata simple
+  }
+
+  return result;
+}

--- a/packages/core/src/ingestion/parser/structured.ts
+++ b/packages/core/src/ingestion/parser/structured.ts
@@ -1,5 +1,13 @@
 // Structured JSON parser — each record becomes one chunk
-import type { ParsedChunk } from '../types.js';
+import type { ChunkMetadata, ParsedChunk } from '../types.js';
+
+const STANDARD_KEYS = new Set([
+  'source_format',
+  'timestamp',
+  'speaker',
+  'section',
+  'turn_index',
+]);
 
 /**
  * Parse structured JSON into chunks.
@@ -31,14 +39,22 @@ export function parseStructured(content: string): ParsedChunk[] {
     }
 
     const position = chunks.length;
+    const { standard, extra } = splitMetadata(
+      record as Record<string, unknown>,
+    );
+    const metadata: ChunkMetadata = {
+      source_format: 'structured',
+      ...standard,
+    };
+    if (Object.keys(extra).length > 0) {
+      metadata.extra = extra;
+    }
+
     chunks.push({
       chunk_id: `chunk_${position.toString().padStart(3, '0')}`,
       content: JSON.stringify(record, null, 2),
       position,
-      metadata: {
-        source_format: 'structured',
-        ...flattenMetadata(record as Record<string, unknown>),
-      },
+      metadata,
     });
   }
 
@@ -46,25 +62,31 @@ export function parseStructured(content: string): ParsedChunk[] {
 }
 
 /**
- * Extract flat string/number/boolean fields from a record for metadata.
+ * Split flat record fields into standard ChunkMetadata fields and extras.
  * Skips nested objects and arrays to keep metadata flat.
  */
-function flattenMetadata(
-  record: Record<string, unknown>,
-): Record<string, string | number | undefined> {
-  const result: Record<string, string | number | undefined> = {};
+function splitMetadata(record: Record<string, unknown>): {
+  standard: Record<string, string | number | undefined>;
+  extra: Record<string, unknown>;
+} {
+  const standard: Record<string, string | number | undefined> = {};
+  const extra: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(record)) {
     // Skip keys that conflict with ChunkMetadata fields
     if (key === 'source_format') continue;
 
-    if (typeof value === 'string') {
-      result[key] = value;
-    } else if (typeof value === 'number') {
-      result[key] = value;
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      // Skip booleans, objects, arrays — keep metadata simple
+      continue;
     }
-    // Skip booleans, objects, arrays — keep metadata simple
+
+    if (STANDARD_KEYS.has(key)) {
+      standard[key] = value;
+    } else {
+      extra[key] = value;
+    }
   }
 
-  return result;
+  return { standard, extra };
 }

--- a/packages/core/src/ingestion/parser/text.test.ts
+++ b/packages/core/src/ingestion/parser/text.test.ts
@@ -30,7 +30,8 @@ describe('parseText', () => {
   });
 
   it('should detect markdown headers and assign section metadata', () => {
-    const text = '# Introduction\n\nSome intro text.\n\n## Methods\n\nSome method text.';
+    const text =
+      '# Introduction\n\nSome intro text.\n\n## Methods\n\nSome method text.';
     const chunks = parseText(text);
     expect(chunks.length).toBeGreaterThanOrEqual(1);
     expect(chunks[0].metadata.section).toBe('Introduction');

--- a/packages/core/src/ingestion/parser/text.test.ts
+++ b/packages/core/src/ingestion/parser/text.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { parseText } from './text.js';
+
+describe('parseText', () => {
+  it('should return empty array for empty string', () => {
+    expect(parseText('')).toEqual([]);
+  });
+
+  it('should return empty array for whitespace-only', () => {
+    expect(parseText('   \n\n   ')).toEqual([]);
+  });
+
+  it('should parse a single paragraph into one chunk', () => {
+    const chunks = parseText('Hello world. This is a test.');
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].content).toBe('Hello world. This is a test.');
+    expect(chunks[0].chunk_id).toBe('chunk_000');
+    expect(chunks[0].position).toBe(0);
+    expect(chunks[0].metadata.source_format).toBe('text');
+  });
+
+  it('should split on double newlines', () => {
+    const text = 'First paragraph.\n\nSecond paragraph.\n\nThird paragraph.';
+    const chunks = parseText(text);
+    // All 3 paragraphs fit within 1600 chars → 1 chunk
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].content).toContain('First paragraph.');
+    expect(chunks[0].content).toContain('Second paragraph.');
+    expect(chunks[0].content).toContain('Third paragraph.');
+  });
+
+  it('should detect markdown headers and assign section metadata', () => {
+    const text = '# Introduction\n\nSome intro text.\n\n## Methods\n\nSome method text.';
+    const chunks = parseText(text);
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+    expect(chunks[0].metadata.section).toBe('Introduction');
+  });
+
+  it('should detect ALL CAPS headers', () => {
+    const text = 'INTRODUCTION\n\nSome text here.\n\nMETHODS\n\nMore text.';
+    const chunks = parseText(text);
+    expect(chunks[0].metadata.section).toBe('INTRODUCTION');
+  });
+
+  it('should not treat short caps strings as headers', () => {
+    const text = 'OK\n\nSome text here.';
+    const chunks = parseText(text);
+    // "OK" is only 2 chars, below the 3-char minimum for caps headers
+    expect(chunks[0].metadata.section).toBeUndefined();
+  });
+
+  it('should handle chunks without any section headers', () => {
+    const text = 'Just a plain paragraph.\n\nAnother paragraph.';
+    const chunks = parseText(text);
+    expect(chunks[0].metadata.section).toBeUndefined();
+  });
+
+  it('should create multiple chunks for long content', () => {
+    // Each paragraph ~200 chars, so ~800 chars per 4 paragraphs
+    // TARGET_CHARS = 1600, so ~8 paragraphs per chunk
+    const paragraphs: string[] = [];
+    for (let i = 0; i < 20; i++) {
+      paragraphs.push(`Paragraph ${i}: ${'x'.repeat(180)}`);
+    }
+    const text = paragraphs.join('\n\n');
+    const chunks = parseText(text);
+
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // All chunks should have proper IDs and positions
+    for (let i = 0; i < chunks.length; i++) {
+      expect(chunks[i].chunk_id).toBe(`chunk_${i.toString().padStart(3, '0')}`);
+      expect(chunks[i].position).toBe(i);
+      expect(chunks[i].metadata.source_format).toBe('text');
+    }
+  });
+
+  it('should have 1-paragraph overlap between chunks', () => {
+    // Create content that will definitely span multiple chunks
+    const paragraphs: string[] = [];
+    for (let i = 0; i < 20; i++) {
+      paragraphs.push(`Unique paragraph ${i}: ${'y'.repeat(180)}`);
+    }
+    const text = paragraphs.join('\n\n');
+    const chunks = parseText(text);
+
+    if (chunks.length >= 2) {
+      // The last paragraph of chunk N should appear in chunk N+1
+      const firstChunkParas = chunks[0].content.split('\n\n');
+      const secondChunkParas = chunks[1].content.split('\n\n');
+      const lastOfFirst = firstChunkParas[firstChunkParas.length - 1];
+      const firstOfSecond = secondChunkParas[0];
+      expect(firstOfSecond).toBe(lastOfFirst);
+    }
+  });
+
+  it('should propagate section to subsequent chunks', () => {
+    const parts = ['# Chapter One'];
+    for (let i = 0; i < 20; i++) {
+      parts.push(`Content paragraph ${i}: ${'z'.repeat(180)}`);
+    }
+    const text = parts.join('\n\n');
+    const chunks = parseText(text);
+
+    // All chunks should inherit the "Chapter One" section
+    for (const chunk of chunks) {
+      expect(chunk.metadata.section).toBe('Chapter One');
+    }
+  });
+
+  it('should handle multi-section documents', () => {
+    const text = [
+      '# Section A',
+      'Content for section A.',
+      '# Section B',
+      'Content for section B.',
+    ].join('\n\n');
+
+    const chunks = parseText(text);
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+    // First chunk starts with Section A
+    expect(chunks[0].metadata.section).toBe('Section A');
+  });
+
+  it('should handle triple+ newlines as paragraph separators', () => {
+    const text = 'Para 1.\n\n\n\nPara 2.\n\n\n\n\nPara 3.';
+    const chunks = parseText(text);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].content).toContain('Para 1.');
+    expect(chunks[0].content).toContain('Para 2.');
+    expect(chunks[0].content).toContain('Para 3.');
+  });
+});

--- a/packages/core/src/ingestion/parser/text.ts
+++ b/packages/core/src/ingestion/parser/text.ts
@@ -1,0 +1,129 @@
+// Plain text parser — paragraph-based chunking with section detection
+import type { ParsedChunk } from '../types.js';
+
+// ~400 tokens at ~4 chars/token
+const TARGET_CHARS = 1600;
+
+/**
+ * Parse plain text into chunks.
+ *
+ * 1. Split on double newlines → paragraphs
+ * 2. Detect section headers (# lines, ALL CAPS lines)
+ * 3. Sliding window: ~400 tokens per chunk, 1-paragraph overlap
+ * 4. Assign section metadata from nearest preceding header
+ */
+export function parseText(content: string): ParsedChunk[] {
+  const paragraphs = splitParagraphs(content);
+  if (paragraphs.length === 0) {
+    return [];
+  }
+
+  // Tag each paragraph with its section header (if any)
+  const tagged = tagSections(paragraphs);
+
+  // Build chunks via sliding window
+  const chunks: ParsedChunk[] = [];
+  let start = 0;
+
+  while (start < tagged.length) {
+    let end = start;
+    let charCount = 0;
+
+    // Accumulate paragraphs until we hit the target
+    while (end < tagged.length && charCount < TARGET_CHARS) {
+      charCount += tagged[end].text.length;
+      end++;
+    }
+
+    // Build chunk content from paragraphs [start, end)
+    const slicedParagraphs = tagged.slice(start, end);
+    const chunkContent = slicedParagraphs
+      .map((p) => p.text)
+      .join('\n\n');
+
+    // Section = nearest preceding header for this window
+    const section = resolveSection(tagged, start);
+
+    const position = chunks.length;
+    chunks.push({
+      chunk_id: `chunk_${position.toString().padStart(3, '0')}`,
+      content: chunkContent,
+      position,
+      metadata: {
+        source_format: 'text',
+        ...(section && { section }),
+      },
+    });
+
+    // Advance with 1-paragraph overlap (unless we consumed everything)
+    if (end >= tagged.length) {
+      break;
+    }
+    start = Math.max(start + 1, end - 1);
+  }
+
+  return chunks;
+}
+
+// --- Internals ---
+
+interface TaggedParagraph {
+  text: string;
+  section?: string; // set if this paragraph IS a header
+}
+
+/**
+ * Split content on double newlines into non-empty paragraphs.
+ */
+function splitParagraphs(content: string): string[] {
+  return content
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+/**
+ * Detect section headers and tag paragraphs.
+ * A header is: a line starting with # (markdown), or an ALL-CAPS line (≥3 chars).
+ */
+function tagSections(paragraphs: string[]): TaggedParagraph[] {
+  return paragraphs.map((text) => {
+    const headerMatch = detectHeader(text);
+    if (headerMatch) {
+      return { text, section: headerMatch };
+    }
+    return { text };
+  });
+}
+
+function detectHeader(text: string): string | undefined {
+  // Check first line only (a paragraph could have multiple lines)
+  const firstLine = text.split('\n')[0].trim();
+
+  // Markdown header: starts with one or more #
+  if (/^#{1,6}\s+/.test(firstLine)) {
+    return firstLine.replace(/^#+\s+/, '').trim();
+  }
+
+  // ALL CAPS line: at least 3 chars, no lowercase letters, allows spaces/punctuation
+  if (firstLine.length >= 3 && /^[^a-z]*$/.test(firstLine) && /[A-Z]/.test(firstLine)) {
+    return firstLine;
+  }
+
+  return undefined;
+}
+
+/**
+ * Find the nearest section header at or before `index`.
+ */
+function resolveSection(
+  tagged: TaggedParagraph[],
+  index: number,
+): string | undefined {
+  for (let i = index; i >= 0; i--) {
+    if (tagged[i].section) {
+      return tagged[i].section;
+    }
+  }
+  return undefined;
+}

--- a/packages/core/src/ingestion/parser/text.ts
+++ b/packages/core/src/ingestion/parser/text.ts
@@ -37,9 +37,7 @@ export function parseText(content: string): ParsedChunk[] {
 
     // Build chunk content from paragraphs [start, end)
     const slicedParagraphs = tagged.slice(start, end);
-    const chunkContent = slicedParagraphs
-      .map((p) => p.text)
-      .join('\n\n');
+    const chunkContent = slicedParagraphs.map((p) => p.text).join('\n\n');
 
     // Section = nearest preceding header for this window
     const section = resolveSection(tagged, start);
@@ -106,7 +104,11 @@ function detectHeader(text: string): string | undefined {
   }
 
   // ALL CAPS line: at least 3 chars, no lowercase letters, allows spaces/punctuation
-  if (firstLine.length >= 3 && /^[^a-z]*$/.test(firstLine) && /[A-Z]/.test(firstLine)) {
+  if (
+    firstLine.length >= 3 &&
+    /^[^a-z]*$/.test(firstLine) &&
+    /[A-Z]/.test(firstLine)
+  ) {
     return firstLine;
   }
 

--- a/packages/core/src/ingestion/profiler.test.ts
+++ b/packages/core/src/ingestion/profiler.test.ts
@@ -71,7 +71,7 @@ describe('profileDocument', () => {
     expect(callArg.prompt).toContain('document analyst');
   });
 
-  it('should include first 5 chunks in prompt even with more chunks', async () => {
+  it('should include first 5 chunks as labeled samples', async () => {
     const llm = makeMockLlm(JSON.stringify(validProfile));
     await profileDocument(makeChunks(10), llm);
 
@@ -79,7 +79,21 @@ describe('profileDocument', () => {
     const prompt = complete.mock.calls[0][0].prompt;
     expect(prompt).toContain('Chunk 1:');
     expect(prompt).toContain('Chunk 5:');
+    // Chunks beyond 5 appear as unlabeled additional content, not as "Chunk N:"
     expect(prompt).not.toContain('Chunk 6:');
+    expect(prompt).toContain('Additional content from later in the document');
+    expect(prompt).toContain('Sample content for chunk 5');
+  });
+
+  it('should not include additional content section for small documents', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+    await profileDocument(makeChunks(3), llm);
+
+    const complete = llm.complete as ReturnType<typeof vi.fn>;
+    const prompt = complete.mock.calls[0][0].prompt;
+    expect(prompt).toContain('Chunk 1:');
+    expect(prompt).toContain('Chunk 3:');
+    expect(prompt).not.toContain('Additional content');
   });
 
   // --- Fallback behavior ---
@@ -209,5 +223,26 @@ describe('profileDocument', () => {
 
     const complete = llm.complete as ReturnType<typeof vi.fn>;
     expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  // --- Format context ---
+
+  it('should include detected document format in prompt', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+    await profileDocument(makeChunks(3, 'Sample', 'structured'), llm);
+
+    const complete = llm.complete as ReturnType<typeof vi.fn>;
+    const prompt = complete.mock.calls[0][0].prompt;
+    expect(prompt).toContain('Detected document format: structured');
+  });
+
+  it('should not contain social-biased example arrays in prompt', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+    await profileDocument(makeChunks(3), llm);
+
+    const complete = llm.complete as ReturnType<typeof vi.fn>;
+    const prompt = complete.mock.calls[0][0].prompt;
+    expect(prompt).not.toContain('["person", "organization", "place"]');
+    expect(prompt).not.toContain('["knows", "works_at"]');
   });
 });

--- a/packages/core/src/ingestion/profiler.test.ts
+++ b/packages/core/src/ingestion/profiler.test.ts
@@ -1,0 +1,125 @@
+import type { LLMProvider } from '@polyg-mcp/shared';
+import { describe, expect, it, vi } from 'vitest';
+import type { DocumentProfile, ParsedChunk } from './types.js';
+import { profileDocument } from './profiler.js';
+
+function makeChunks(count: number, format: 'text' | 'structured' = 'text'): ParsedChunk[] {
+  return Array.from({ length: count }, (_, i) => ({
+    chunk_id: `chunk_${i.toString().padStart(3, '0')}`,
+    content: `Sample content for chunk ${i}. This has some interesting data.`,
+    position: i,
+    metadata: { source_format: format },
+  }));
+}
+
+const validProfile: DocumentProfile = {
+  document_type: 'technical_doc',
+  domain: 'engineering',
+  entity_types_expected: ['component', 'service', 'developer'],
+  relationship_types_expected: ['depends_on', 'maintains', 'calls'],
+  causal_patterns: ['failure → outage', 'deployment → incident'],
+  temporal_structure: 'explicit_timestamps',
+  extraction_focus: 'Focus on system components, dependencies, and incidents.',
+  confidence_calibration: {
+    explicit_causation: 1.0,
+    strong_implication: 0.85,
+    weak_inference: 0.6,
+  },
+};
+
+function makeMockLlm(response: string): LLMProvider {
+  return {
+    complete: vi.fn().mockResolvedValue(response),
+  } as unknown as LLMProvider;
+}
+
+describe('profileDocument', () => {
+  it('should parse LLM response into a DocumentProfile', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+    const result = await profileDocument(makeChunks(5), llm);
+
+    expect(result.document_type).toBe('technical_doc');
+    expect(result.domain).toBe('engineering');
+    expect(result.entity_types_expected).toContain('component');
+    expect(result.temporal_structure).toBe('explicit_timestamps');
+  });
+
+  it('should call LLM with prompt containing chunk content', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+    await profileDocument(makeChunks(3), llm);
+
+    const complete = llm.complete as ReturnType<typeof vi.fn>;
+    expect(complete).toHaveBeenCalledOnce();
+    const callArg = complete.mock.calls[0][0];
+    expect(callArg.responseFormat).toBe('json');
+    expect(callArg.prompt).toContain('Sample content for chunk 0');
+    expect(callArg.prompt).toContain('document analyst');
+  });
+
+  it('should fall back to default profile on LLM failure', async () => {
+    const llm = {
+      complete: vi.fn().mockRejectedValue(new Error('API error')),
+    } as unknown as LLMProvider;
+
+    const result = await profileDocument(makeChunks(3), llm);
+
+    // Falls back to GENERIC_PROFILE for 'text' format
+    expect(result.document_type).toBe('generic');
+    expect(result.domain).toBe('general');
+  });
+
+  it('should fall back on invalid JSON from LLM', async () => {
+    const llm = makeMockLlm('not valid json');
+    const result = await profileDocument(makeChunks(3), llm);
+    expect(result.document_type).toBe('generic');
+  });
+
+  it('should fall back on schema validation failure', async () => {
+    const llm = makeMockLlm(JSON.stringify({ document_type: 'test' })); // missing fields
+    const result = await profileDocument(makeChunks(3), llm);
+    expect(result.document_type).toBe('generic');
+  });
+
+  it('should cache successful profiles by document_type', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+    const cache = new Map<string, DocumentProfile>();
+
+    await profileDocument(makeChunks(3), llm, { cache });
+
+    expect(cache.has('technical_doc')).toBe(true);
+    expect(cache.get('technical_doc')!.domain).toBe('engineering');
+  });
+
+  it('should use cached profile on LLM failure', async () => {
+    const cache = new Map<string, DocumentProfile>();
+    cache.set('cached_type', validProfile);
+
+    const llm = {
+      complete: vi.fn().mockRejectedValue(new Error('fail')),
+    } as unknown as LLMProvider;
+
+    const result = await profileDocument(makeChunks(3), llm, { cache });
+    // Should return the cached profile rather than generic default
+    expect(result.document_type).toBe('technical_doc');
+  });
+
+  it('should not call LLM more than once per invocation', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+    await profileDocument(makeChunks(10), llm);
+
+    const complete = llm.complete as ReturnType<typeof vi.fn>;
+    expect(complete).toHaveBeenCalledOnce();
+  });
+
+  it('should include first 5 chunks in prompt even with more chunks', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+    await profileDocument(makeChunks(10), llm);
+
+    const complete = llm.complete as ReturnType<typeof vi.fn>;
+    const prompt = complete.mock.calls[0][0].prompt;
+    expect(prompt).toContain('Chunk 1:');
+    expect(prompt).toContain('Chunk 5:');
+    // Should NOT include chunk 6+
+    expect(prompt).not.toContain('Chunk 6:');
+  });
+});

--- a/packages/core/src/ingestion/profiler.test.ts
+++ b/packages/core/src/ingestion/profiler.test.ts
@@ -1,12 +1,20 @@
 import type { LLMProvider } from '@polyg-mcp/shared';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearProfileCache,
+  getProfileCacheSize,
+  profileDocument,
+} from './profiler.js';
 import type { DocumentProfile, ParsedChunk } from './types.js';
-import { profileDocument } from './profiler.js';
 
-function makeChunks(count: number, format: 'text' | 'structured' = 'text'): ParsedChunk[] {
+function makeChunks(
+  count: number,
+  contentPrefix = 'Sample content for chunk',
+  format: 'text' | 'structured' = 'text',
+): ParsedChunk[] {
   return Array.from({ length: count }, (_, i) => ({
     chunk_id: `chunk_${i.toString().padStart(3, '0')}`,
-    content: `Sample content for chunk ${i}. This has some interesting data.`,
+    content: `${contentPrefix} ${i}. This has some interesting data.`,
     position: i,
     metadata: { source_format: format },
   }));
@@ -34,14 +42,21 @@ function makeMockLlm(response: string): LLMProvider {
 }
 
 describe('profileDocument', () => {
+  beforeEach(() => {
+    clearProfileCache();
+  });
+
+  // --- Basic profiling ---
+
   it('should parse LLM response into a DocumentProfile', async () => {
     const llm = makeMockLlm(JSON.stringify(validProfile));
-    const result = await profileDocument(makeChunks(5), llm);
+    const { profile, cached } = await profileDocument(makeChunks(5), llm);
 
-    expect(result.document_type).toBe('technical_doc');
-    expect(result.domain).toBe('engineering');
-    expect(result.entity_types_expected).toContain('component');
-    expect(result.temporal_structure).toBe('explicit_timestamps');
+    expect(cached).toBe(false);
+    expect(profile.document_type).toBe('technical_doc');
+    expect(profile.domain).toBe('engineering');
+    expect(profile.entity_types_expected).toContain('component');
+    expect(profile.temporal_structure).toBe('explicit_timestamps');
   });
 
   it('should call LLM with prompt containing chunk content', async () => {
@@ -56,61 +71,6 @@ describe('profileDocument', () => {
     expect(callArg.prompt).toContain('document analyst');
   });
 
-  it('should fall back to default profile on LLM failure', async () => {
-    const llm = {
-      complete: vi.fn().mockRejectedValue(new Error('API error')),
-    } as unknown as LLMProvider;
-
-    const result = await profileDocument(makeChunks(3), llm);
-
-    // Falls back to GENERIC_PROFILE for 'text' format
-    expect(result.document_type).toBe('generic');
-    expect(result.domain).toBe('general');
-  });
-
-  it('should fall back on invalid JSON from LLM', async () => {
-    const llm = makeMockLlm('not valid json');
-    const result = await profileDocument(makeChunks(3), llm);
-    expect(result.document_type).toBe('generic');
-  });
-
-  it('should fall back on schema validation failure', async () => {
-    const llm = makeMockLlm(JSON.stringify({ document_type: 'test' })); // missing fields
-    const result = await profileDocument(makeChunks(3), llm);
-    expect(result.document_type).toBe('generic');
-  });
-
-  it('should cache successful profiles by document_type', async () => {
-    const llm = makeMockLlm(JSON.stringify(validProfile));
-    const cache = new Map<string, DocumentProfile>();
-
-    await profileDocument(makeChunks(3), llm, { cache });
-
-    expect(cache.has('technical_doc')).toBe(true);
-    expect(cache.get('technical_doc')!.domain).toBe('engineering');
-  });
-
-  it('should use cached profile on LLM failure', async () => {
-    const cache = new Map<string, DocumentProfile>();
-    cache.set('cached_type', validProfile);
-
-    const llm = {
-      complete: vi.fn().mockRejectedValue(new Error('fail')),
-    } as unknown as LLMProvider;
-
-    const result = await profileDocument(makeChunks(3), llm, { cache });
-    // Should return the cached profile rather than generic default
-    expect(result.document_type).toBe('technical_doc');
-  });
-
-  it('should not call LLM more than once per invocation', async () => {
-    const llm = makeMockLlm(JSON.stringify(validProfile));
-    await profileDocument(makeChunks(10), llm);
-
-    const complete = llm.complete as ReturnType<typeof vi.fn>;
-    expect(complete).toHaveBeenCalledOnce();
-  });
-
   it('should include first 5 chunks in prompt even with more chunks', async () => {
     const llm = makeMockLlm(JSON.stringify(validProfile));
     await profileDocument(makeChunks(10), llm);
@@ -119,7 +79,135 @@ describe('profileDocument', () => {
     const prompt = complete.mock.calls[0][0].prompt;
     expect(prompt).toContain('Chunk 1:');
     expect(prompt).toContain('Chunk 5:');
-    // Should NOT include chunk 6+
     expect(prompt).not.toContain('Chunk 6:');
+  });
+
+  // --- Fallback behavior ---
+
+  it('should fall back to default profile on LLM failure', async () => {
+    const llm = {
+      complete: vi.fn().mockRejectedValue(new Error('API error')),
+    } as unknown as LLMProvider;
+
+    const { profile, cached } = await profileDocument(makeChunks(3), llm);
+
+    expect(cached).toBe(false);
+    expect(profile.document_type).toBe('generic');
+    expect(profile.domain).toBe('general');
+  });
+
+  it('should fall back on invalid JSON from LLM', async () => {
+    const llm = makeMockLlm('not valid json');
+    const { profile } = await profileDocument(makeChunks(3), llm);
+    expect(profile.document_type).toBe('generic');
+  });
+
+  it('should fall back on schema validation failure', async () => {
+    const llm = makeMockLlm(JSON.stringify({ document_type: 'test' }));
+    const { profile } = await profileDocument(makeChunks(3), llm);
+    expect(profile.document_type).toBe('generic');
+  });
+
+  // --- Cache hit / miss ---
+
+  it('should return cached profile on second call with same content', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+    const chunks = makeChunks(5);
+
+    const first = await profileDocument(chunks, llm);
+    const second = await profileDocument(chunks, llm);
+
+    expect(first.cached).toBe(false);
+    expect(second.cached).toBe(true);
+    expect(second.profile.document_type).toBe('technical_doc');
+
+    // LLM should only be called once
+    const complete = llm.complete as ReturnType<typeof vi.fn>;
+    expect(complete).toHaveBeenCalledOnce();
+  });
+
+  it('should call LLM for different content (cache miss)', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+
+    const chunksA = makeChunks(3, 'Document A content');
+    const chunksB = makeChunks(3, 'Document B content');
+
+    const first = await profileDocument(chunksA, llm);
+    const second = await profileDocument(chunksB, llm);
+
+    expect(first.cached).toBe(false);
+    expect(second.cached).toBe(false);
+
+    const complete = llm.complete as ReturnType<typeof vi.fn>;
+    expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not cache fallback profiles (allows retry on transient errors)', async () => {
+    const llm = {
+      complete: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('transient error'))
+        .mockResolvedValueOnce(JSON.stringify(validProfile)),
+    } as unknown as LLMProvider;
+
+    const chunks = makeChunks(3);
+
+    // First call: LLM fails → fallback, NOT cached
+    const first = await profileDocument(chunks, llm);
+    expect(first.cached).toBe(false);
+    expect(first.profile.document_type).toBe('generic');
+
+    // Second call: same content, LLM succeeds → should call LLM again (not cached)
+    const second = await profileDocument(chunks, llm);
+    expect(second.cached).toBe(false);
+    expect(second.profile.document_type).toBe('technical_doc');
+
+    const complete = llm.complete as ReturnType<typeof vi.fn>;
+    expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  // --- Cache management ---
+
+  it('should evict oldest entry when cache exceeds max size', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+
+    // Fill cache with 100 unique entries
+    for (let i = 0; i < 100; i++) {
+      const chunks = makeChunks(1, `Unique document content ${i}`);
+      await profileDocument(chunks, llm);
+    }
+    expect(getProfileCacheSize()).toBe(100);
+
+    // Add one more — should evict the first
+    const chunks101 = makeChunks(1, 'Unique document content 100');
+    await profileDocument(chunks101, llm);
+    expect(getProfileCacheSize()).toBe(100);
+
+    // First entry should be evicted — calling it again should miss
+    const llm2 = makeMockLlm(JSON.stringify(validProfile));
+    const firstChunks = makeChunks(1, 'Unique document content 0');
+    const result = await profileDocument(firstChunks, llm2);
+    expect(result.cached).toBe(false);
+
+    const complete = llm2.complete as ReturnType<typeof vi.fn>;
+    expect(complete).toHaveBeenCalledOnce();
+  });
+
+  it('should clear cache with clearProfileCache()', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+    const chunks = makeChunks(3);
+
+    await profileDocument(chunks, llm);
+    expect(getProfileCacheSize()).toBe(1);
+
+    clearProfileCache();
+    expect(getProfileCacheSize()).toBe(0);
+
+    // Same content should now miss
+    const result = await profileDocument(chunks, llm);
+    expect(result.cached).toBe(false);
+
+    const complete = llm.complete as ReturnType<typeof vi.fn>;
+    expect(complete).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/core/src/ingestion/profiler.test.ts
+++ b/packages/core/src/ingestion/profiler.test.ts
@@ -106,20 +106,21 @@ describe('profileDocument', () => {
     const { profile, cached } = await profileDocument(makeChunks(3), llm);
 
     expect(cached).toBe(false);
-    expect(profile.document_type).toBe('generic');
+    // Chunks have format 'text' → falls back to TEXT_PROFILE
+    expect(profile.document_type).toBe('text_document');
     expect(profile.domain).toBe('general');
   });
 
   it('should fall back on invalid JSON from LLM', async () => {
     const llm = makeMockLlm('not valid json');
     const { profile } = await profileDocument(makeChunks(3), llm);
-    expect(profile.document_type).toBe('generic');
+    expect(profile.document_type).toBe('text_document');
   });
 
   it('should fall back on schema validation failure', async () => {
     const llm = makeMockLlm(JSON.stringify({ document_type: 'test' }));
     const { profile } = await profileDocument(makeChunks(3), llm);
-    expect(profile.document_type).toBe('generic');
+    expect(profile.document_type).toBe('text_document');
   });
 
   // --- Cache hit / miss ---
@@ -169,7 +170,7 @@ describe('profileDocument', () => {
     // First call: LLM fails → fallback, NOT cached
     const first = await profileDocument(chunks, llm);
     expect(first.cached).toBe(false);
-    expect(first.profile.document_type).toBe('generic');
+    expect(first.profile.document_type).toBe('text_document');
 
     // Second call: same content, LLM succeeds → should call LLM again (not cached)
     const second = await profileDocument(chunks, llm);

--- a/packages/core/src/ingestion/profiler.test.ts
+++ b/packages/core/src/ingestion/profiler.test.ts
@@ -208,6 +208,32 @@ describe('profileDocument', () => {
     expect(complete).toHaveBeenCalledOnce();
   });
 
+  it('should expire cached entries after TTL', async () => {
+    const llm = makeMockLlm(JSON.stringify(validProfile));
+    const chunks = makeChunks(5);
+
+    // First call — cache miss
+    const first = await profileDocument(chunks, llm);
+    expect(first.cached).toBe(false);
+
+    // Second call — cache hit (within TTL)
+    const second = await profileDocument(chunks, llm);
+    expect(second.cached).toBe(true);
+
+    // Advance time past TTL (30 minutes)
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 31 * 60 * 1000);
+
+    // Third call — cache expired, should miss
+    const third = await profileDocument(chunks, llm);
+    expect(third.cached).toBe(false);
+
+    vi.useRealTimers();
+
+    const complete = llm.complete as ReturnType<typeof vi.fn>;
+    expect(complete).toHaveBeenCalledTimes(2); // first + third (not second)
+  });
+
   it('should clear cache with clearProfileCache()', async () => {
     const llm = makeMockLlm(JSON.stringify(validProfile));
     const chunks = makeChunks(3);

--- a/packages/core/src/ingestion/profiler.ts
+++ b/packages/core/src/ingestion/profiler.ts
@@ -42,7 +42,7 @@ export async function profileDocument(
 
   // Cache miss — call LLM
   try {
-    const prompt = buildProfilerPrompt(chunks);
+    const prompt = buildProfilerPrompt(chunks, sourceFormat);
     const raw = await llm.complete({ prompt, responseFormat: 'json' });
     const profile = DocumentProfileSchema.parse(JSON.parse(raw));
 
@@ -87,16 +87,22 @@ function hashSample(chunks: ParsedChunk[]): string {
   return createHash('sha256').update(sample).digest('hex');
 }
 
-function buildProfilerPrompt(chunks: ParsedChunk[]): string {
-  // Concatenate content for a broad sample
-  const allContent = chunks.map((c) => c.content).join('\n');
-  const sampleText = allContent.slice(0, SAMPLE_CHARS);
-
-  // First N chunks as structured examples
+function buildProfilerPrompt(chunks: ParsedChunk[], sourceFormat: string): string {
+  // First N chunks as labeled examples (primary signal)
   const sampleChunks = chunks.slice(0, SAMPLE_CHUNKS);
   const chunkSamples = sampleChunks
     .map((c, i) => `Chunk ${i + 1}:\n${c.content}`)
     .join('\n\n');
+
+  // Additional content beyond the first N chunks for broader coverage
+  const remainingChunks = chunks.slice(SAMPLE_CHUNKS);
+  let additionalSample = '';
+  if (remainingChunks.length > 0) {
+    additionalSample = remainingChunks
+      .map((c) => c.content)
+      .join('\n')
+      .slice(0, SAMPLE_CHARS);
+  }
 
   const system = [
     'You are a document analyst. Given a sample of a document, determine its type,',
@@ -105,9 +111,9 @@ function buildProfilerPrompt(chunks: ParsedChunk[]): string {
     '{',
     '  "document_type": string,          // e.g. "conversation", "technical_doc", "report", "log"',
     '  "domain": string,                 // e.g. "general", "medical", "engineering", "legal"',
-    '  "entity_types_expected": string[], // e.g. ["person", "organization", "place"]',
-    '  "relationship_types_expected": string[], // e.g. ["knows", "works_at"]',
-    '  "causal_patterns": string[],      // e.g. ["decision → action", "event → reaction"]',
+    '  "entity_types_expected": string[], // Types of entities found in the document (be domain-specific)',
+    '  "relationship_types_expected": string[], // Types of relationships between entities (be domain-specific)',
+    '  "causal_patterns": string[],      // Cause-effect patterns present in the document',
     '  "temporal_structure": "explicit_timestamps" | "session_ordered" | "implicit",',
     '  "extraction_focus": string,       // human-readable guidance for extraction',
     '  "confidence_calibration": {',
@@ -120,15 +126,22 @@ function buildProfilerPrompt(chunks: ParsedChunk[]): string {
     'Output ONLY valid JSON. Be specific to the document content.',
   ].join('\n');
 
-  const user = [
-    'Here is a sample from the document:',
+  const userParts = [
+    `Detected document format: ${sourceFormat}`,
     '',
-    sampleText,
-    '',
-    `First ${sampleChunks.length} chunks:`,
+    `First ${sampleChunks.length} chunks from the document:`,
     '',
     chunkSamples,
-  ].join('\n');
+  ];
 
-  return `${system}\n\n${user}`;
+  if (additionalSample) {
+    userParts.push(
+      '',
+      'Additional content from later in the document:',
+      '',
+      additionalSample,
+    );
+  }
+
+  return `${system}\n\n${userParts.join('\n')}`;
 }

--- a/packages/core/src/ingestion/profiler.ts
+++ b/packages/core/src/ingestion/profiler.ts
@@ -54,7 +54,9 @@ export async function profileDocument(
   try {
     const prompt = buildProfilerPrompt(chunks, sourceFormat);
     const raw = await llm.complete({ prompt, responseFormat: 'json' });
-    const profile = DocumentProfileSchema.parse(JSON.parse(stripJsonFences(raw)));
+    const profile = DocumentProfileSchema.parse(
+      JSON.parse(stripJsonFences(raw)),
+    );
 
     // Store in cache (evict oldest if full)
     if (profileCache.size >= MAX_CACHE_SIZE) {

--- a/packages/core/src/ingestion/profiler.ts
+++ b/packages/core/src/ingestion/profiler.ts
@@ -1,0 +1,99 @@
+// LLM document profiler — analyzes document samples to produce a DocumentProfile
+import type { LLMProvider } from '@polyg-mcp/shared';
+import { getDefaultProfile } from './profiles.js';
+import type { DocumentProfile, ParsedChunk } from './types.js';
+import { DocumentProfileSchema } from './types.js';
+
+// ~2000 tokens at ~4 chars/token
+const SAMPLE_CHARS = 8000;
+const SAMPLE_CHUNKS = 5;
+
+export interface ProfilerOptions {
+  cache?: Map<string, DocumentProfile>;
+}
+
+/**
+ * Profile a document using LLM analysis.
+ *
+ * Takes a sample of chunks, asks the LLM to classify the document and
+ * determine extraction parameters. Results are cached by document_type.
+ * Falls back to default profiles on any failure.
+ */
+export async function profileDocument(
+  chunks: ParsedChunk[],
+  llm: LLMProvider,
+  options?: ProfilerOptions,
+): Promise<DocumentProfile> {
+  const cache = options?.cache;
+  const sourceFormat = chunks[0]?.metadata.source_format ?? 'text';
+
+  try {
+    const prompt = buildProfilerPrompt(chunks);
+    const raw = await llm.complete({ prompt, responseFormat: 'json' });
+    const profile = DocumentProfileSchema.parse(JSON.parse(raw));
+
+    // Cache by document_type
+    if (cache) {
+      cache.set(profile.document_type, profile);
+    }
+
+    return profile;
+  } catch {
+    // Check cache for a previously profiled result
+    if (cache && cache.size > 0) {
+      // Return any cached profile — better than a generic default
+      const first = cache.values().next();
+      if (!first.done) {
+        return first.value;
+      }
+    }
+
+    return getDefaultProfile(sourceFormat);
+  }
+}
+
+function buildProfilerPrompt(chunks: ParsedChunk[]): string {
+  // Concatenate content for a broad sample
+  const allContent = chunks.map((c) => c.content).join('\n');
+  const sampleText = allContent.slice(0, SAMPLE_CHARS);
+
+  // First N chunks as structured examples
+  const sampleChunks = chunks.slice(0, SAMPLE_CHUNKS);
+  const chunkSamples = sampleChunks
+    .map((c, i) => `Chunk ${i + 1}:\n${c.content}`)
+    .join('\n\n');
+
+  const system = [
+    'You are a document analyst. Given a sample of a document, determine its type,',
+    'domain, and the kinds of knowledge that can be extracted from it.',
+    'Return a JSON object with exactly these fields:',
+    '{',
+    '  "document_type": string,          // e.g. "conversation", "technical_doc", "report", "log"',
+    '  "domain": string,                 // e.g. "general", "medical", "engineering", "legal"',
+    '  "entity_types_expected": string[], // e.g. ["person", "organization", "place"]',
+    '  "relationship_types_expected": string[], // e.g. ["knows", "works_at"]',
+    '  "causal_patterns": string[],      // e.g. ["decision → action", "event → reaction"]',
+    '  "temporal_structure": "explicit_timestamps" | "session_ordered" | "implicit",',
+    '  "extraction_focus": string,       // human-readable guidance for extraction',
+    '  "confidence_calibration": {',
+    '    "explicit_causation": number,   // 0.0-1.0, for directly stated causation',
+    '    "strong_implication": number,   // 0.0-1.0, for clearly implied causation',
+    '    "weak_inference": number        // 0.0-1.0, for loosely suggested causation',
+    '  }',
+    '}',
+    '',
+    'Output ONLY valid JSON. Be specific to the document content.',
+  ].join('\n');
+
+  const user = [
+    'Here is a sample from the document:',
+    '',
+    sampleText,
+    '',
+    `First ${sampleChunks.length} chunks:`,
+    '',
+    chunkSamples,
+  ].join('\n');
+
+  return `${system}\n\n${user}`;
+}

--- a/packages/core/src/ingestion/profiler.ts
+++ b/packages/core/src/ingestion/profiler.ts
@@ -11,9 +11,15 @@ import { DocumentProfileSchema } from './types.js';
 const SAMPLE_CHARS = 8000;
 const SAMPLE_CHUNKS = 5;
 const MAX_CACHE_SIZE = 100;
+const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
-// Module-level cache: content hash → DocumentProfile
-const profileCache = new Map<string, DocumentProfile>();
+interface CacheEntry {
+  profile: DocumentProfile;
+  cachedAt: number;
+}
+
+// Module-level cache: content hash → CacheEntry (with TTL)
+const profileCache = new Map<string, CacheEntry>();
 
 export interface ProfileResult {
   profile: DocumentProfile;
@@ -35,10 +41,13 @@ export async function profileDocument(
   const sourceFormat = chunks[0]?.metadata.source_format ?? 'text';
   const hash = hashSample(chunks);
 
-  // Cache hit — skip LLM
+  // Cache hit — skip LLM (check TTL)
   const cached = profileCache.get(hash);
   if (cached) {
-    return { profile: cached, cached: true };
+    if (Date.now() - cached.cachedAt < CACHE_TTL_MS) {
+      return { profile: cached.profile, cached: true };
+    }
+    profileCache.delete(hash);
   }
 
   // Cache miss — call LLM
@@ -54,7 +63,7 @@ export async function profileDocument(
         profileCache.delete(oldest);
       }
     }
-    profileCache.set(hash, profile);
+    profileCache.set(hash, { profile, cachedAt: Date.now() });
 
     return { profile, cached: false };
   } catch {

--- a/packages/core/src/ingestion/profiler.ts
+++ b/packages/core/src/ingestion/profiler.ts
@@ -1,4 +1,6 @@
 // LLM document profiler — analyzes document samples to produce a DocumentProfile
+// Maintains an internal content-hash cache to avoid redundant LLM calls.
+import { createHash } from 'node:crypto';
 import type { LLMProvider } from '@polyg-mcp/shared';
 import { getDefaultProfile } from './profiles.js';
 import type { DocumentProfile, ParsedChunk } from './types.js';
@@ -7,49 +9,82 @@ import { DocumentProfileSchema } from './types.js';
 // ~2000 tokens at ~4 chars/token
 const SAMPLE_CHARS = 8000;
 const SAMPLE_CHUNKS = 5;
+const MAX_CACHE_SIZE = 100;
 
-export interface ProfilerOptions {
-  cache?: Map<string, DocumentProfile>;
+// Module-level cache: content hash → DocumentProfile
+const profileCache = new Map<string, DocumentProfile>();
+
+export interface ProfileResult {
+  profile: DocumentProfile;
+  cached: boolean;
 }
 
 /**
  * Profile a document using LLM analysis.
  *
- * Takes a sample of chunks, asks the LLM to classify the document and
- * determine extraction parameters. Results are cached by document_type.
- * Falls back to default profiles on any failure.
+ * Computes a SHA-256 hash of the content sample and checks the internal cache.
+ * On cache hit, returns the cached profile without calling the LLM.
+ * On miss, calls the LLM, validates the response, and caches successful results.
+ * Falls back to default profiles on any failure (fallbacks are NOT cached).
  */
 export async function profileDocument(
   chunks: ParsedChunk[],
   llm: LLMProvider,
-  options?: ProfilerOptions,
-): Promise<DocumentProfile> {
-  const cache = options?.cache;
+): Promise<ProfileResult> {
   const sourceFormat = chunks[0]?.metadata.source_format ?? 'text';
+  const hash = hashSample(chunks);
 
+  // Cache hit — skip LLM
+  const cached = profileCache.get(hash);
+  if (cached) {
+    return { profile: cached, cached: true };
+  }
+
+  // Cache miss — call LLM
   try {
     const prompt = buildProfilerPrompt(chunks);
     const raw = await llm.complete({ prompt, responseFormat: 'json' });
     const profile = DocumentProfileSchema.parse(JSON.parse(raw));
 
-    // Cache by document_type
-    if (cache) {
-      cache.set(profile.document_type, profile);
-    }
-
-    return profile;
-  } catch {
-    // Check cache for a previously profiled result
-    if (cache && cache.size > 0) {
-      // Return any cached profile — better than a generic default
-      const first = cache.values().next();
-      if (!first.done) {
-        return first.value;
+    // Store in cache (evict oldest if full)
+    if (profileCache.size >= MAX_CACHE_SIZE) {
+      const oldest = profileCache.keys().next().value;
+      if (oldest !== undefined) {
+        profileCache.delete(oldest);
       }
     }
+    profileCache.set(hash, profile);
 
-    return getDefaultProfile(sourceFormat);
+    return { profile, cached: false };
+  } catch {
+    // Do NOT cache fallback — preserves retry on transient LLM errors
+    return { profile: getDefaultProfile(sourceFormat), cached: false };
   }
+}
+
+/**
+ * Clear the internal profile cache.
+ * Exported for testing — ensures test isolation.
+ */
+export function clearProfileCache(): void {
+  profileCache.clear();
+}
+
+/**
+ * Get the current cache size. Exported for testing.
+ */
+export function getProfileCacheSize(): number {
+  return profileCache.size;
+}
+
+// --- Internals ---
+
+function hashSample(chunks: ParsedChunk[]): string {
+  const sample = chunks
+    .map((c) => c.content)
+    .join('\n')
+    .slice(0, SAMPLE_CHARS);
+  return createHash('sha256').update(sample).digest('hex');
 }
 
 function buildProfilerPrompt(chunks: ParsedChunk[]): string {

--- a/packages/core/src/ingestion/profiler.ts
+++ b/packages/core/src/ingestion/profiler.ts
@@ -87,7 +87,10 @@ function hashSample(chunks: ParsedChunk[]): string {
   return createHash('sha256').update(sample).digest('hex');
 }
 
-function buildProfilerPrompt(chunks: ParsedChunk[], sourceFormat: string): string {
+function buildProfilerPrompt(
+  chunks: ParsedChunk[],
+  sourceFormat: string,
+): string {
   // First N chunks as labeled examples (primary signal)
   const sampleChunks = chunks.slice(0, SAMPLE_CHUNKS);
   const chunkSamples = sampleChunks

--- a/packages/core/src/ingestion/profiler.ts
+++ b/packages/core/src/ingestion/profiler.ts
@@ -2,6 +2,7 @@
 // Maintains an internal content-hash cache to avoid redundant LLM calls.
 import { createHash } from 'node:crypto';
 import type { LLMProvider } from '@polyg-mcp/shared';
+import { stripJsonFences } from './normalize.js';
 import { getDefaultProfile } from './profiles.js';
 import type { DocumentProfile, ParsedChunk } from './types.js';
 import { DocumentProfileSchema } from './types.js';
@@ -44,7 +45,7 @@ export async function profileDocument(
   try {
     const prompt = buildProfilerPrompt(chunks, sourceFormat);
     const raw = await llm.complete({ prompt, responseFormat: 'json' });
-    const profile = DocumentProfileSchema.parse(JSON.parse(raw));
+    const profile = DocumentProfileSchema.parse(JSON.parse(stripJsonFences(raw)));
 
     // Store in cache (evict oldest if full)
     if (profileCache.size >= MAX_CACHE_SIZE) {

--- a/packages/core/src/ingestion/profiles.test.ts
+++ b/packages/core/src/ingestion/profiles.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   CONVERSATION_PROFILE,
   GENERIC_PROFILE,
+  getDefaultProfile,
   STRUCTURED_PROFILE,
   TEXT_PROFILE,
-  getDefaultProfile,
 } from './profiles.js';
 import { DocumentProfileSchema } from './types.js';
 
@@ -46,9 +46,7 @@ describe('profiles', () => {
     });
 
     it('should have explicit_timestamps temporal structure', () => {
-      expect(STRUCTURED_PROFILE.temporal_structure).toBe(
-        'explicit_timestamps',
-      );
+      expect(STRUCTURED_PROFILE.temporal_structure).toBe('explicit_timestamps');
     });
 
     it('should have structured_data document type', () => {

--- a/packages/core/src/ingestion/profiles.test.ts
+++ b/packages/core/src/ingestion/profiles.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   CONVERSATION_PROFILE,
   GENERIC_PROFILE,
+  STRUCTURED_PROFILE,
+  TEXT_PROFILE,
   getDefaultProfile,
 } from './profiles.js';
 import { DocumentProfileSchema } from './types.js';
@@ -22,6 +24,38 @@ describe('profiles', () => {
     });
   });
 
+  describe('TEXT_PROFILE', () => {
+    it('should be a valid DocumentProfile', () => {
+      const result = DocumentProfileSchema.safeParse(TEXT_PROFILE);
+      expect(result.success).toBe(true);
+    });
+
+    it('should have implicit temporal structure', () => {
+      expect(TEXT_PROFILE.temporal_structure).toBe('implicit');
+    });
+
+    it('should have text_document document type', () => {
+      expect(TEXT_PROFILE.document_type).toBe('text_document');
+    });
+  });
+
+  describe('STRUCTURED_PROFILE', () => {
+    it('should be a valid DocumentProfile', () => {
+      const result = DocumentProfileSchema.safeParse(STRUCTURED_PROFILE);
+      expect(result.success).toBe(true);
+    });
+
+    it('should have explicit_timestamps temporal structure', () => {
+      expect(STRUCTURED_PROFILE.temporal_structure).toBe(
+        'explicit_timestamps',
+      );
+    });
+
+    it('should have structured_data document type', () => {
+      expect(STRUCTURED_PROFILE.document_type).toBe('structured_data');
+    });
+  });
+
   describe('GENERIC_PROFILE', () => {
     it('should be a valid DocumentProfile', () => {
       const result = DocumentProfileSchema.safeParse(GENERIC_PROFILE);
@@ -38,12 +72,12 @@ describe('profiles', () => {
       expect(getDefaultProfile('conversation')).toBe(CONVERSATION_PROFILE);
     });
 
-    it('should return GENERIC_PROFILE for text format', () => {
-      expect(getDefaultProfile('text')).toBe(GENERIC_PROFILE);
+    it('should return TEXT_PROFILE for text format', () => {
+      expect(getDefaultProfile('text')).toBe(TEXT_PROFILE);
     });
 
-    it('should return GENERIC_PROFILE for structured format', () => {
-      expect(getDefaultProfile('structured')).toBe(GENERIC_PROFILE);
+    it('should return STRUCTURED_PROFILE for structured format', () => {
+      expect(getDefaultProfile('structured')).toBe(STRUCTURED_PROFILE);
     });
 
     it('should return GENERIC_PROFILE for auto format', () => {

--- a/packages/core/src/ingestion/profiles.ts
+++ b/packages/core/src/ingestion/profiles.ts
@@ -27,6 +27,70 @@ export const CONVERSATION_PROFILE: DocumentProfile = {
   },
 };
 
+export const TEXT_PROFILE: DocumentProfile = {
+  document_type: 'text_document',
+  domain: 'general',
+  entity_types_expected: [
+    'person',
+    'organization',
+    'location',
+    'concept',
+    'event',
+  ],
+  relationship_types_expected: [
+    'related_to',
+    'part_of',
+    'located_in',
+    'authored_by',
+    'describes',
+  ],
+  causal_patterns: [
+    'cause → effect',
+    'action → outcome',
+    'condition → consequence',
+  ],
+  temporal_structure: 'implicit',
+  extraction_focus:
+    'Extract entities, relationships, and facts from prose. Look for stated claims, descriptions, and narrative connections.',
+  confidence_calibration: {
+    explicit_causation: 1.0,
+    strong_implication: 0.85,
+    weak_inference: 0.65,
+  },
+};
+
+export const STRUCTURED_PROFILE: DocumentProfile = {
+  document_type: 'structured_data',
+  domain: 'general',
+  entity_types_expected: [
+    'record',
+    'entity',
+    'category',
+    'metric',
+    'status',
+  ],
+  relationship_types_expected: [
+    'contains',
+    'references',
+    'categorized_as',
+    'measured_by',
+    'depends_on',
+  ],
+  causal_patterns: [
+    'trigger → event',
+    'threshold → alert',
+    'input → output',
+  ],
+  temporal_structure: 'explicit_timestamps',
+  extraction_focus:
+    'Extract structured records, their categories, metrics, and cross-references. Use field values as entity properties.',
+  confidence_calibration: {
+    explicit_causation: 1.0,
+    strong_implication: 0.9,
+    weak_inference: 0.7,
+  },
+};
+
 export const GENERIC_PROFILE: DocumentProfile = {
   document_type: 'generic',
   domain: 'general',
@@ -56,6 +120,10 @@ export function getDefaultProfile(format: InputFormat): DocumentProfile {
   switch (format) {
     case 'conversation':
       return CONVERSATION_PROFILE;
+    case 'text':
+      return TEXT_PROFILE;
+    case 'structured':
+      return STRUCTURED_PROFILE;
     default:
       return GENERIC_PROFILE;
   }

--- a/packages/core/src/ingestion/profiles.ts
+++ b/packages/core/src/ingestion/profiles.ts
@@ -62,13 +62,7 @@ export const TEXT_PROFILE: DocumentProfile = {
 export const STRUCTURED_PROFILE: DocumentProfile = {
   document_type: 'structured_data',
   domain: 'general',
-  entity_types_expected: [
-    'record',
-    'entity',
-    'category',
-    'metric',
-    'status',
-  ],
+  entity_types_expected: ['record', 'entity', 'category', 'metric', 'status'],
   relationship_types_expected: [
     'contains',
     'references',
@@ -76,11 +70,7 @@ export const STRUCTURED_PROFILE: DocumentProfile = {
     'measured_by',
     'depends_on',
   ],
-  causal_patterns: [
-    'trigger → event',
-    'threshold → alert',
-    'input → output',
-  ],
+  causal_patterns: ['trigger → event', 'threshold → alert', 'input → output'],
   temporal_structure: 'explicit_timestamps',
   extraction_focus:
     'Extract structured records, their categories, metrics, and cross-references. Use field values as entity properties.',

--- a/packages/core/src/ingestion/slow-path.test.ts
+++ b/packages/core/src/ingestion/slow-path.test.ts
@@ -271,7 +271,7 @@ describe('runSlowPath', () => {
     expect(result.skippedChunks).toBe(0);
   });
 
-  it('should skip chunks with invalid LLM JSON', async () => {
+  it('should skip chunks with invalid LLM JSON without retrying', async () => {
     vi.mocked(llm.complete).mockResolvedValue('not valid json');
 
     const chunks = makeChunks(1);
@@ -284,8 +284,34 @@ describe('runSlowPath', () => {
       deps,
     );
 
+    // SyntaxError is non-retryable — should only call LLM once
+    expect(llm.complete).toHaveBeenCalledTimes(1);
     expect(result.skippedChunks).toBe(1);
     expect(result.extractedChunks).toBe(0);
+    expect(result.warnings[0]).toContain('invalid response structure');
+  });
+
+  it('should skip chunks with wrong JSON shape without retrying', async () => {
+    // Valid JSON but missing required fields → ZodError
+    vi.mocked(llm.complete).mockResolvedValue(
+      JSON.stringify({ wrong: 'schema' }),
+    );
+
+    const chunks = makeChunks(1);
+    const fastResult = makeFastResult(1);
+
+    const result = await runSlowPath(
+      chunks,
+      fastResult,
+      CONVERSATION_PROFILE,
+      deps,
+    );
+
+    // ZodError is non-retryable — should only call LLM once
+    expect(llm.complete).toHaveBeenCalledTimes(1);
+    expect(result.skippedChunks).toBe(1);
+    expect(result.extractedChunks).toBe(0);
+    expect(result.warnings[0]).toContain('invalid response structure');
   });
 
   it('should accumulate entity map across chunks', async () => {

--- a/packages/core/src/ingestion/slow-path.ts
+++ b/packages/core/src/ingestion/slow-path.ts
@@ -134,7 +134,9 @@ async function extractWithRetry(
         prompt,
         responseFormat: 'json',
       });
-      const parsed = ChunkExtractionSchema.parse(JSON.parse(stripJsonFences(raw)));
+      const parsed = ChunkExtractionSchema.parse(
+        JSON.parse(stripJsonFences(raw)),
+      );
       return normalizeExtraction(parsed);
     } catch (err) {
       // Schema validation errors won't resolve on retry with the same prompt

--- a/packages/core/src/ingestion/slow-path.ts
+++ b/packages/core/src/ingestion/slow-path.ts
@@ -76,6 +76,7 @@ export async function runSlowPath(
       neighborhood,
       deps,
       result.warnings,
+      chunks.length,
     );
     if (!extraction) {
       result.skippedChunks++;
@@ -115,8 +116,14 @@ async function extractWithRetry(
   neighborhood: NeighborhoodContext,
   deps: IngestionDeps,
   warnings: string[],
+  totalChunks: number,
 ): Promise<ChunkExtraction | null> {
-  const { system, user } = buildExtractionPrompt(chunk, profile, neighborhood);
+  const { system, user } = buildExtractionPrompt(
+    chunk,
+    profile,
+    neighborhood,
+    totalChunks,
+  );
   const prompt = `${system}\n\n${user}`;
 
   for (let attempt = 0; attempt < 2; attempt++) {

--- a/packages/core/src/ingestion/slow-path.ts
+++ b/packages/core/src/ingestion/slow-path.ts
@@ -253,11 +253,21 @@ async function writeChunkExtraction(
   }
 
   // 4. Causal links — findOrCreate nodes + addLink + link to entities + link to event
+  const seenCausalDescriptions = new Set<string>();
   for (const causal of extraction.causal_links) {
     try {
       const causeNode = await causalGraph.findOrCreate(causal.cause);
       const effectNode = await causalGraph.findOrCreate(causal.effect);
-      result.causal_nodes_created += 2; // approximate: findOrCreate may reuse
+      const causeKey = causal.cause.toLowerCase().trim();
+      const effectKey = causal.effect.toLowerCase().trim();
+      if (!seenCausalDescriptions.has(causeKey)) {
+        seenCausalDescriptions.add(causeKey);
+        result.causal_nodes_created++;
+      }
+      if (!seenCausalDescriptions.has(effectKey)) {
+        seenCausalDescriptions.add(effectKey);
+        result.causal_nodes_created++;
+      }
 
       await causalGraph.addLink(
         causeNode.uuid,

--- a/packages/core/src/ingestion/slow-path.ts
+++ b/packages/core/src/ingestion/slow-path.ts
@@ -4,6 +4,7 @@ import { CausalGraph } from '../graphs/causal.js';
 import { EntityGraph } from '../graphs/entity.js';
 import { TemporalGraph } from '../graphs/temporal.js';
 import { buildExtractionPrompt } from './extraction-prompt.js';
+import { normalizeExtraction } from './normalize.js';
 import type { NeighborhoodContext } from './neighborhood.js';
 import { gather2HopNeighborhood } from './neighborhood.js';
 import type {
@@ -132,7 +133,8 @@ async function extractWithRetry(
         prompt,
         responseFormat: 'json',
       });
-      return ChunkExtractionSchema.parse(JSON.parse(raw));
+      const parsed = ChunkExtractionSchema.parse(JSON.parse(raw));
+      return normalizeExtraction(parsed);
     } catch (err) {
       if (attempt === 1) {
         warnings.push(

--- a/packages/core/src/ingestion/slow-path.ts
+++ b/packages/core/src/ingestion/slow-path.ts
@@ -6,7 +6,7 @@ import { TemporalGraph } from '../graphs/temporal.js';
 import { buildExtractionPrompt } from './extraction-prompt.js';
 import type { NeighborhoodContext } from './neighborhood.js';
 import { gather2HopNeighborhood } from './neighborhood.js';
-import { normalizeExtraction } from './normalize.js';
+import { normalizeExtraction, stripJsonFences } from './normalize.js';
 import type {
   ChunkExtraction,
   DocumentProfile,
@@ -133,7 +133,7 @@ async function extractWithRetry(
         prompt,
         responseFormat: 'json',
       });
-      const parsed = ChunkExtractionSchema.parse(JSON.parse(raw));
+      const parsed = ChunkExtractionSchema.parse(JSON.parse(stripJsonFences(raw)));
       return normalizeExtraction(parsed);
     } catch (err) {
       if (attempt === 1) {

--- a/packages/core/src/ingestion/slow-path.ts
+++ b/packages/core/src/ingestion/slow-path.ts
@@ -4,9 +4,9 @@ import { CausalGraph } from '../graphs/causal.js';
 import { EntityGraph } from '../graphs/entity.js';
 import { TemporalGraph } from '../graphs/temporal.js';
 import { buildExtractionPrompt } from './extraction-prompt.js';
-import { normalizeExtraction } from './normalize.js';
 import type { NeighborhoodContext } from './neighborhood.js';
 import { gather2HopNeighborhood } from './neighborhood.js';
+import { normalizeExtraction } from './normalize.js';
 import type {
   ChunkExtraction,
   DocumentProfile,

--- a/packages/core/src/ingestion/slow-path.ts
+++ b/packages/core/src/ingestion/slow-path.ts
@@ -1,5 +1,6 @@
 // Slow path — per-chunk LLM extraction + graph writes
 import type { Entity } from '@polyg-mcp/shared';
+import { ZodError } from 'zod';
 import { CausalGraph } from '../graphs/causal.js';
 import { EntityGraph } from '../graphs/entity.js';
 import { TemporalGraph } from '../graphs/temporal.js';
@@ -136,13 +137,20 @@ async function extractWithRetry(
       const parsed = ChunkExtractionSchema.parse(JSON.parse(stripJsonFences(raw)));
       return normalizeExtraction(parsed);
     } catch (err) {
+      // Schema validation errors won't resolve on retry with the same prompt
+      if (err instanceof ZodError || err instanceof SyntaxError) {
+        warnings.push(
+          `Extraction failed for chunk ${chunk.chunk_id} (invalid response structure): ${errMsg(err)}`,
+        );
+        return null;
+      }
       if (attempt === 1) {
         warnings.push(
           `Extraction failed for chunk ${chunk.chunk_id} after 2 attempts: ${errMsg(err)}`,
         );
         return null;
       }
-      // retry
+      // retry on transient errors (network/timeout)
     }
   }
 

--- a/packages/core/src/ingestion/types.ts
+++ b/packages/core/src/ingestion/types.ts
@@ -36,6 +36,7 @@ export interface ChunkMetadata {
   speaker?: string;
   section?: string;
   turn_index?: number; // conversation turn number
+  extra?: Record<string, unknown>; // Domain-specific metadata from parsers
 }
 
 // --- Document Profile ---


### PR DESCRIPTION
## Summary

- **Text parser** (`parser/text.ts`): Paragraph-based chunking with sliding window (~400 tokens), 1-paragraph overlap, section header detection (markdown `#` + ALL CAPS)
- **Structured JSON parser** (`parser/structured.ts`): JSON array/single object to chunks, flat metadata extraction, `source_format` protection
- **LLM document profiler** (`profiler.ts`): Analyzes document samples via LLM to produce `DocumentProfile` with internal content-hash cache (SHA-256), oldest-first eviction at 100 entries, fallback to defaults on failure (fallbacks NOT cached to allow retry on transient errors)
- **Parser wiring**: Replaced `throw Error('Not implemented')` stubs in `parser/index.ts` with `parseText()` and `parseStructured()` calls
- **Orchestrator integration**: `ingest()` now calls `profileDocument()` when no `profileOverride` is provided, with accurate cost tracking (`profiler_calls=0` on cache hit)

## Key design decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Cache key | SHA-256 of content sample (first ~8000 chars) | Deterministic, exact-match, fast |
| Cache storage | Module-level `Map` | Zero deps, process-lifetime, low cardinality |
| Cache size cap | 100 entries, oldest-first eviction | Safety valve against memory leaks |
| Cache fallback profiles? | No | Transient LLM errors shouldn't block future profiling |
| Profiler return type | `{ profile, cached }` | Enables accurate `profiler_calls` cost reporting |
| Text chunking | ~1600 chars (~400 tokens) per chunk | Balances context vs granularity |
| Chunk overlap | 1 paragraph | Preserves cross-boundary context |

## Test plan

- [x] Text parser: 13 unit tests (empty input, section detection, chunking, overlap, multi-section)
- [x] Structured parser: 10 unit tests (arrays, single objects, metadata, primitives, source_format protection)
- [x] Profiler: 11 unit tests (basic profiling, fallback behavior, cache hit/miss, eviction, clearProfileCache)
- [x] Parser wiring: 8 tests (auto-detect routing, format override)
- [x] Orchestrator integration: 16 tests (full pipeline, cache-hit cost tracking, profiler_calls=0/1)
- [x] Full suite: 1013 tests passing, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)